### PR TITLE
feat(backend) GET /api/user/me を実装

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -279,7 +279,7 @@ func postSignout(c echo.Context) error {
 func getMe(c echo.Context) error {
 	userID, err := getUserIdFromSession(c.Request())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "you are not signed in")
+		return echo.NewHTTPError(http.StatusUnauthorized, "you are not signed in") // TODO 記法が決まったら修正
 	}
 
 	response := GetMeResponse{JIAUserID: userID}


### PR DESCRIPTION
## やったこと
* `GET /api/user/me` を実装
  - ログインしていたら，自分自身の情報（day1では `JIAUserId` のみの想定）を返す
  - ログインしていなかったら401を返す 
  - ref: [予選問題モブプロ 各エンドポイントのロジックを合わせる会](https://scrapbox.io/ISUCON11/%E4%BA%88%E9%81%B8%E5%95%8F%E9%A1%8C%E3%83%A2%E3%83%96%E3%83%97%E3%83%AD_%E5%90%84%E3%82%A8%E3%83%B3%E3%83%89%E3%83%9D%E3%82%A4%E3%83%B3%E3%83%88%E3%81%AE%E3%83%AD%E3%82%B8%E3%83%83%E3%82%AF%E3%82%92%E5%90%88%E3%82%8F%E3%81%9B%E3%82%8B%E4%BC%9A)

## 対応issue
#23 

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
* ログイン時の動作確認は、まだちゃんとは行っていません。