### PR TITLE
feat(backend): 開発用の制約を考慮してSchemaのDrop順序を変更

### DIFF
--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -5,6 +5,7 @@ DROP TABLE IF EXISTS `graph`;
 DROP TABLE IF EXISTS `isu_log`;
 DROP TABLE IF EXISTS `isu`;
 DROP TABLE IF EXISTS `user`;
+
 CREATE TABLE `isu` (
   `jia_isu_uuid` CHAR(36) PRIMARY KEY,
   `name` VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## やったこと
開発用の外部キー制約でinitializeに利用している0_Schema.sqlがエラー吐くようになっていたので修正しました。

## 対応issue
なし

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
Docker上でpost initializeが成功することまで確認済み（外部キー制約消えちゃうけど）