### PR TITLE
fix(backend): 500を発生させない

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -970,10 +970,7 @@ func calculateGraphData(isuLogCluster []IsuLog) ([]byte, error) {
 		for _, cond := range strings.Split(log.Condition, ",") {
 			keyValue := strings.Split(cond, "=")
 			if len(keyValue) != 2 {
-				return nil, fmt.Errorf("invalid condition %s", cond)
-			}
-			if _, ok := scorePerCondition[keyValue[0]]; !ok {
-				return nil, fmt.Errorf("invalid condition %s", cond)
+				continue //形式に従っていないものは無視
 			}
 			conditions[keyValue[0]] = (keyValue[1] != "false")
 		}
@@ -981,8 +978,11 @@ func calculateGraphData(isuLogCluster []IsuLog) ([]byte, error) {
 		//trueになっているものは減点
 		for key, enabled := range conditions {
 			if enabled {
-				graph.Score += scorePerCondition[key]
-				graph.Detail[key] += scorePerCondition[key]
+				score, ok := scorePerCondition[key]
+				if ok {
+					graph.Score += score
+					graph.Detail[key] += score
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## やったこと
scorePerConditionの失敗時に単に無視して、500を発生させない

## 対応issue
#63

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
