### PR TITLE
feat(ci): Add label ci setting for documentation

### DIFF
--- a/.github/label-path-mapping.yml
+++ b/.github/label-path-mapping.yml
@@ -6,3 +6,5 @@ benchmarker:
   - bench/**/*
 infrastructure:
   - provisioning/**/*
+documentation:
+  - development/doc/**/*


### PR DESCRIPTION
## やったこと

- `developement/doc/` 配下が更新された場合に `documentation` labelが付与されるように設定

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
