### PR TITLE
fix(backend) 500エラーをc.NoContentで返すよう変更

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1460,7 +1460,7 @@ func postIsuCondition(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 	if count != 0 {
-		return c.String(http.StatusConflict, "isu_cndition already exist")
+		return c.String(http.StatusConflict, "isu_condition already exist")
 	}
 	//insert
 	_, err = tx.Exec("INSERT INTO `isu_condition`"+


### PR DESCRIPTION
## やったこと
* `echo.NewHTTPError` を使っている箇所で、500番エラーのものを `c.NoContent` で返すように変更

## 対応issue
#139 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
* ログにメッセージ出すようにする修正を一部混ぜてしまいました．ログについての全部の修正は， #143 に紐づくPRで行います。