### PR TITLE
fix(backend) 4xxエラーをc.Stringで返すよう変更

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1144,7 +1144,7 @@ func getAllIsuConditions(c echo.Context) error {
 	if startTimeStr != "" {
 		_, err = strconv.ParseInt(startTimeStr, 10, 64)
 		if err != nil {
-			return c.String(http.StatusBadRequest, "bad format: cursor_end_time")
+			return c.String(http.StatusBadRequest, "bad format: start_time")
 		}
 	}
 


### PR DESCRIPTION
## やったこと
* 4xxエラーを `echo.NewHTTPError()` ではなく `c.String()` で返却するようにしました

## 対応issue
#139 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
#197 に依存しています
