### PR TITLE
[frontend] authページの実装

### DIFF
--- a/webapp/frontend/src/pages/Auth.tsx
+++ b/webapp/frontend/src/pages/Auth.tsx
@@ -1,8 +1,12 @@
+import { useHistory } from 'react-router-dom'
+import Card from '../components/UI/Card'
 import { useDispatchContext } from '../context/state'
 import apis, { debugGetJWT } from '../lib/apis'
+import logo from '/@/assets/logo.png'
 
 const Auth = () => {
   const dispatch = useDispatchContext()
+  const history = useHistory()
 
   // TODO: 外部APIのログインページにリダイレクト
   const click = async () => {
@@ -11,10 +15,25 @@ const Auth = () => {
 
     const me = await apis.getUserMe()
     dispatch({ type: 'login', user: me })
+    history.push('/')
   }
   return (
-    <div>
-      <button onClick={click}>ISU協会でログイン</button>
+    <div className="flex justify-center p-10">
+      <div className="flex justify-center w-full max-w-lg">
+        <Card>
+          <div className="flex flex-col items-center w-full">
+            <img src={logo} alt="isucondition" />
+            <div className="mt-4 text-lg">ISUとつくる新しい明日</div>
+            <div className="mt-6 w-full border-b border-outline" />
+            <button
+              className="mt-10 px-5 py-2 h-12 text-white-primary font-bold bg-button rounded-3xl"
+              onClick={click}
+            >
+              JIAのアカウントでログイン
+            </button>
+          </div>
+        </Card>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## やったこと
authページの実装

## 対応issue
Close #206 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
![image](https://user-images.githubusercontent.com/48485650/124009968-3305fc80-da19-11eb-842a-057618fa8b2c.png)
キャッチフレーズは仮置き
