### PR TITLE
[backend,bench] ISU APIにおいてunixtimeを入れるため構造体のフィールドの型を変更

### DIFF
--- a/extra/isuapi/cmd/standalone/main.go
+++ b/extra/isuapi/cmd/standalone/main.go
@@ -57,7 +57,7 @@ type IsuNotification struct {
 	IsSitting bool   `json:"is_sitting"`
 	Condition string `json:"condition"`
 	Message   string `json:"message"`
-	Timestamp string `json:"timestamp"`
+	Timestamp int64  `json:"timestamp"`
 }
 
 func getEnv(key string, defaultValue string) string {


### PR DESCRIPTION
## やったこと
* unixtimeを入れようとしている構造体のフィールドの型が `string` でエラーが出ていたため， `int64` に修正

## 対応issue
なし

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
