### PR TITLE
[backend]未ログイン時のエラーメッセージの統一

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -267,7 +267,7 @@ func main() {
 	e.GET("/register", getIndex)
 	e.GET("/login", getIndex)
 	// Assets
-	e.Static("/assets", frontendContentsPath+"/assets")
+	e.Static("/assets", frontendContentsPath + "/assets")
 
 	mySQLConnectionData = NewMySQLConnectionEnv()
 


### PR DESCRIPTION
## やったこと
未ログイン時のエラーメッセージが`you are not sign in`と`you are not signed in`で分かれてたから統一した
いつかの話し合いで過去形のほうが正しそうという話だったため後者に統一

## 対応issue
Close #230 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
