### PR TITLE
fix(backend) JIAサービスへのURL生成方法を統一

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -558,7 +558,7 @@ func postIsu(c echo.Context) error {
 	}
 
 	// JIAにisuのactivateをリクエスト
-	targetURL := fmt.Sprintf("%s/api/activate", getJIAServiceURL()) // TODO fetchCatalogFromJIAとリクエストURLを合わせる
+	targetURL := getJIAServiceURL() + "/api/activate"
 	port, err := strconv.Atoi(getEnv("SERVER_PORT", "3000"))
 	if err != nil {
 		c.Logger().Errorf("bad port number: %v", err)
@@ -899,7 +899,7 @@ func deleteIsu(c echo.Context) error {
 	}
 
 	// JIAにisuのdeactivateをリクエスト
-	targetURL := fmt.Sprintf("%s/api/deactivate", getJIAServiceURL())
+	targetURL := getJIAServiceURL() + "/api/deactivate"
 	port, err := strconv.Atoi(getEnv("SERVER_PORT", "3000"))
 	if err != nil {
 		c.Logger().Errorf("bad port number: %v", err)


### PR DESCRIPTION
## やったこと
* JIAサービスへのURL生成方法を， `fetchCatalogFromJIA` の 以下の形式に合わせるように修正

```go
targetURLStr := getJIAServiceURL() + "/api/catalog/" + catalogID
```

## 対応issue
#155 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
