### PR TITLE
fix(backend) 論理削除チェックの書き方を統一

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1498,7 +1498,7 @@ func postIsuCondition(c echo.Context) error {
 
 	// jia_isu_uuid が存在するかを確認
 	var count int
-	err = tx.Get(&count, "SELECT COUNT(*) FROM `isu` WHERE `jia_isu_uuid` = ?  and `is_deleted`=false", jiaIsuUUID) //TODO: 記法の統一
+	err = tx.Get(&count, "SELECT COUNT(*) FROM `isu` WHERE `jia_isu_uuid` = ?  and `is_deleted` = false", jiaIsuUUID) //TODO: 記法の統一
 	if err != nil {
 		c.Logger().Errorf("failed to select: %v", err)
 		return c.NoContent(http.StatusInternalServerError)


### PR DESCRIPTION
## やったこと
* 論理削除チェックの書き方を `is_deleted = false` に統一

## 対応issue
#144 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
