### PR TITLE
fix(backend) `getAllIsuConditions` の「自分のISUをDBから取得」処理でのエラーハンドリングのバグを修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1215,7 +1215,6 @@ func getAllIsuConditions(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 	if len(isuList) == 0 {
-		fmt.Println("no isu") // FIXME
 		return c.JSON(http.StatusOK, isuList)
 	}
 


### PR DESCRIPTION
## やったこと
* `getAllIsuConditions` の `getAllIsuConditions` の「自分のISUをDBから取得」処理でのエラーハンドリングで，エラーの際，正しく500を返せていなかったバグを修正
* 加えて，仕様変更に近い修正として，自分が持っているISUがなかった場合， 404を返すのではなく，空配列が返るようにした

## 対応issue
なし

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
* 「自分が持っているISUがなかった場合， 404を返すのではなく，空配列が返る」件については議論あるとおもうので，意見ほしいです