### PR TITLE
fix(infra): permission_boundary に policy を指定するようにした

### DIFF
--- a/provisioning/terraform/iam-user_ghaction-qualify.tf
+++ b/provisioning/terraform/iam-user_ghaction-qualify.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_user" "ghaction-qualify-dev" {
   name                 = "ghaction-qualify-dev"
-  permissions_boundary = data.aws_iam_role.isu-admin.arn
+  permissions_boundary = data.aws_iam_policy.isu-admin.arn
 }
 
 resource "aws_iam_user_policy" "ghaction-qualify-dev-packer" {
@@ -9,7 +9,7 @@ resource "aws_iam_user_policy" "ghaction-qualify-dev-packer" {
   policy = data.aws_iam_policy_document.ghaction-qualify-dev-packer.json
 }
 
-data "aws_iam_role" "isu-admin" {
+data "aws_iam_policy" "isu-admin" {
   name = "IsuAdmin"
 }
 


### PR DESCRIPTION
## やったこと

- fix #259 
    - permission_boundary には role ではなく policy の arn を入れるのが正解っぽい
    - 参考: https://isucon.slack.com/archives/C01R89Z60GL/p1625492147378200

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
