### PR TITLE
fix(backend) postIsuConditionで複数のconditionを一度にpost出来るよう変更

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1552,7 +1552,7 @@ func postIsuCondition(c echo.Context) error {
 
 	//isu_conditionに記録
 	for _, cond := range req {
-		// parser
+		// parse
 		timestamp := time.Unix(cond.Timestamp, 0)
 
 		if !conditionFormat.Match([]byte(cond.Condition)) {


### PR DESCRIPTION
## やったこと
* postIsuConditionにおいて，複数のconditionを一度にpost出来るよう変更しました．
  - conditionの配列を受け取る
  - insertで一度に複数のrecordを登録
  - uniqueチェックは， MySQLのunique制約違反のエラーをキャッチすることで判定

## 対応issue
#262 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
* 参考実装はN+1のinsertにする方法も在ると思いますが，どこまでボトルネックになるか分からなかったので，まとめてinsertにしています．
  * N+!にしたほうがいいという意見あったら教えてください
* ちょっと自信無いので，なにかコメントあったら教えていただけるとありがたいです