### PR TITLE
fix(backend) getAllIsuConditionの仕様変更のため，getIsuConditionからDBアクセスを関数に抽出

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1431,7 +1431,7 @@ func getIsuConditions(c echo.Context) error {
 }
 
 func getIsuConditionsFromDB(jiaIsuUUID string, cursorEndTime time.Time, conditionLevel map[string]interface{}, startTime time.Time,
-	limit int, isuName string) ([]GetIsuConditionResponse, error) {
+	limit int, isuName string) ([]*GetIsuConditionResponse, error) {
 
 	conditions := []IsuCondition{}
 	var err error
@@ -1457,7 +1457,7 @@ func getIsuConditionsFromDB(jiaIsuUUID string, cursorEndTime time.Time, conditio
 	}
 
 	//condition_levelでの絞り込み
-	conditionsResponse := []GetIsuConditionResponse{}
+	conditionsResponse := []*GetIsuConditionResponse{}
 	for _, c := range conditions {
 		var cLevel string
 		warnCount := strings.Count(c.Condition, "=true")
@@ -1481,7 +1481,7 @@ func getIsuConditionsFromDB(jiaIsuUUID string, cursorEndTime time.Time, conditio
 				ConditionLevel: cLevel,
 				Message:        c.Message,
 			}
-			conditionsResponse = append(conditionsResponse, data)
+			conditionsResponse = append(conditionsResponse, &data)
 		}
 	}
 


### PR DESCRIPTION
## やったこと
* `getAllIsuCondition` を localhostへのAPIコールを経由して実現するのではなく，素直にDBへのクエリを発行することでやりたい（これについてのPRは #277 ）
* そこで，`getAllIsuCondition` で発行する予定のDBのクエリと `getIsuCondition` で発行しているDBのクエリは多く重複しているため，共通のメソッドに切り出した

## 対応issue
#264 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
