### PR TITLE
fix(frontend): dockerignoreの配置場所をビルドコンテキストのルートに

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+webapp/frontend/node_modules
+webapp/frontend/dist

--- a/webapp/frontend/.dockerignore
+++ b/webapp/frontend/.dockerignore
@@ -1,2 +1,0 @@
-/node_modules
-/dist


### PR DESCRIPTION
## やったこと
frontendのdockerignoreが読み込まれるように配置を移動した

## 対応issue

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
#216 で解決しきれていなかった問題の対応
リポジトリのルートに置くものが増えるのはあまりよくないが、`docker-compose-*.yml`で指定しているビルドコンテキストのルートにおかないとdockerignoreは読み込まれないので
