### PR TITLE
fix(backend): getIsuGraph 1時間以下切り捨て

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1093,7 +1093,7 @@ func getIsuGraph(c echo.Context) error {
 		c.Logger().Errorf("date is invalid format")
 		return c.String(http.StatusBadRequest, "date is invalid format")
 	}
-	date := time.Unix(dateInt64, 0)
+	date := truncateAfterHours(time.Unix(dateInt64, 0))
 
 	tx, err := db.Beginx()
 	if err != nil {


### PR DESCRIPTION
## やったこと
getIsuGraphのdateパラメーターが任意の時間をとれるようになっていたので、一時間単位で指定するように修正。

## 対応issue

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
