### PR TITLE
[frontend] Iconのボタンを中央揃えに

### DIFF
--- a/webapp/frontend/src/components/IsuDetail/NameEdit.tsx
+++ b/webapp/frontend/src/components/IsuDetail/NameEdit.tsx
@@ -48,10 +48,16 @@ const FinishEditButtons = ({
 }) => {
   return (
     <div className="flex gap-2 items-center">
-      <button onClick={confirmEdit} className="focus:outline-none">
+      <button
+        onClick={confirmEdit}
+        className="flex items-center focus:outline-none"
+      >
         <HiOutlineCheck size="20" />
       </button>
-      <button onClick={finishEdit} className="text-error focus:outline-none">
+      <button
+        onClick={finishEdit}
+        className="flex items-center text-error focus:outline-none"
+      >
         <IoMdClose size="20" />
       </button>
     </div>
@@ -60,7 +66,10 @@ const FinishEditButtons = ({
 
 const StartEditButton = ({ startEdit }: { startEdit: () => void }) => {
   return (
-    <button onClick={startEdit} className="focus:outline-none">
+    <button
+      onClick={startEdit}
+      className="flex items-center focus:outline-none"
+    >
       <HiOutlinePencil size="20" />
     </button>
   )


### PR DESCRIPTION
## やったこと
Iconのボタンを中央揃えにした

after
![image](https://user-images.githubusercontent.com/48485650/125062664-9c58d000-e0e9-11eb-8a2f-094425250024.png)


## 対応issue
Close #324 

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
