### PR TITLE
fix(bench, isuapi) ISUからIsuConditionにpostするデータが配列に変更されていなかったのを修正

### DIFF
--- a/extra/jiaapi/cmd/standalone/main.go
+++ b/extra/jiaapi/cmd/standalone/main.go
@@ -349,8 +349,6 @@ func (state *IsuConditionPoster) keepPosting(ctx context.Context) {
 		}
 
 		func() {
-			fmt.Println("go go go!!")
-
 			resp, err := http.Post(
 				targetURL, "application/json",
 				bytes.NewBuffer(payload),


### PR DESCRIPTION
## やったこと
* backendの `postIsuCondition` が配列を受け取るよう仕様変更されたのに，ISU APIの方は修正されていなかったため，配列を投げるようISU APIを修正

## 対応issue
なし

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
