### PR TITLE
fix(bench): POST /initialize のタイムアウト値を実行時オプションで指定できるようにした

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -41,6 +41,7 @@ var (
 	promOut            string
 	showVersion        bool
 
+	initializeTimeout time.Duration
 	// TODO: isucon11-portal に差し替え
 	//reporter benchrun.Reporter
 )
@@ -78,7 +79,9 @@ func init() {
 	flag.BoolVar(&showVersion, "version", false, "show version and exit 1")
 
 	timeoutDuration := ""
+	initializeTimeoutDuration := ""
 	flag.StringVar(&timeoutDuration, "timeout", "10s", "request timeout duration")
+	flag.StringVar(&initializeTimeoutDuration, "initialize-timeout", "20s", "request timeout duration of POST /initialize")
 
 	flag.Parse()
 
@@ -87,6 +90,12 @@ func init() {
 		panic(err)
 	}
 	agent.DefaultRequestTimeout = timeout
+
+	initializeTimeout, err = time.ParseDuration(initializeTimeoutDuration)
+	if err != nil {
+		panic(err)
+	}
+
 }
 
 func checkError(err error) (critical bool, timeout bool, deduction bool) {
@@ -216,6 +225,10 @@ func main() {
 	defer cancel()
 
 	s, err := scenario.NewScenario(jiaServiceURL)
+	if err != nil {
+		panic(err)
+	}
+	s = s.WithInitilizeTimeout(initializeTimeout)
 	scheme := "http"
 	if useTLS {
 		scheme = "https"

--- a/bench/scenario/prepare.go
+++ b/bench/scenario/prepare.go
@@ -35,7 +35,7 @@ func (s *Scenario) Prepare(ctx context.Context, step *isucandar.BenchmarkStep) e
 
 	//initialize
 	initializer, err := s.NewAgent(
-		agent.WithNoCache(), agent.WithNoCookie(), agent.WithTimeout(20*time.Second),
+		agent.WithNoCache(), agent.WithNoCookie(), agent.WithTimeout(s.initializeTimeout),
 	)
 	if err != nil {
 		return failure.NewError(ErrCritical, err)

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -28,6 +28,9 @@ type Scenario struct {
 	virtualTimeMulti time.Duration //時間が何倍速になっているか
 	jiaServiceURL    string
 
+	// POST /initialize の猶予時間
+	initializeTimeout time.Duration
+
 	// 競技者の実装言語
 	Language string
 
@@ -46,12 +49,18 @@ func NewScenario(jiaServiceURL string) (*Scenario, error) {
 	return &Scenario{
 		// TODO: シナリオを初期化する
 		//realTimeStart: time.Now()
-		virtualTimeStart: time.Date(2020, 7, 1, 0, 0, 0, 0, time.Local), //TODO: ちゃんと決める
-		virtualTimeMulti: 3000,                                          //5分=300秒に一回 => 1秒に10回
-		jiaServiceURL:    jiaServiceURL,
-		normalUsers:      []*model.User{},
-		companyUsers:     []*model.User{},
+		virtualTimeStart:  time.Date(2020, 7, 1, 0, 0, 0, 0, time.Local), //TODO: ちゃんと決める
+		virtualTimeMulti:  3000,                                          //5分=300秒に一回 => 1秒に10回
+		jiaServiceURL:     jiaServiceURL,
+		initializeTimeout: 20 * time.Second,
+		normalUsers:       []*model.User{},
+		companyUsers:      []*model.User{},
 	}, nil
+}
+
+func (s *Scenario) WithInitilizeTimeout(t time.Duration) *Scenario {
+	s.initializeTimeout = t
+	return s
 }
 
 func (s *Scenario) NewAgent(opts ...agent.AgentOption) (*agent.Agent, error) {


### PR DESCRIPTION
## やったこと

POST /initialize のタイムアウト値を実行時オプションで指定できるようにした

## 対応issue

resolved #337

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
