### PR TITLE
feat(backend): putIsuIconをpostIsuに統合

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1013,8 +1013,7 @@ func getIsuIcon(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	// TODO: putIsuIconでjpgも受け付けるなら対応が必要
-	return c.Blob(http.StatusOK, "image/png", image)
+	return c.Blob(http.StatusOK, "", image)
 }
 
 //  GET /api/isu/{jia_isu_uuid}/graph


### PR DESCRIPTION
## やったこと
postIsuのリクエスト情報はFormValueで受け取るようにした
postIsuのリクエストでの`image`フィールドはoptionalで、空ならデフォルト画像を使用するようにした
postIsuでの画像の扱いに合わせてgetIsuIconでもcontentTypeをつけないようにした

## 対応issue
close #359 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
