### PR TITLE
feat(infra): 競技者 VM が 2core/2GB で上がるよう kernel param を指定

### DIFF
--- a/provisioning/packer/contestant.jsonnet
+++ b/provisioning/packer/contestant.jsonnet
@@ -2,5 +2,13 @@ local base = import './base.libsonnet';
 
 base {
   arg_variant: 'contestant',
-  provisioners_plus:: [],
+  provisioners_plus:: [
+    {
+      type: 'shell',
+      inline: [
+        'sudo sh -c "echo GRUB_CMDLINE_LINUX=\'maxcpus=2 mem=2G\' > /etc/default/grub.d/99-isucon.cfg"',
+        'sudo update-grub',
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
## やったこと

- 競技者 VM が 2core/2GB で上がるよう kernel param を指定
    - ひとまず仮置
    - [参考 URL](https://scrapbox.io/ISUCON11/%E4%BA%88%E9%81%B8%E4%BF%AE%E6%AD%A3%E8%A9%B1%E3%81%97%E5%90%88%E3%81%84%EF%BC%88%E6%BA%96%E5%82%99%E4%BC%9AFB%E3%82%92%E3%81%86%E3%81%91%E3%81%A6%EF%BC%89#60e93c6bdfe7cd00004219c4)

## 対応issue

#374 

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
