### PR TITLE
fix(backend): 0_Schema.sqlからgraphテーブルの定義を削除

### DIFF
--- a/webapp/sql/0_Schema.sql
+++ b/webapp/sql/0_Schema.sql
@@ -1,7 +1,6 @@
 -- TODO: 各カラムの varchar の大きさを調整する (#51)
 
 DROP TABLE IF EXISTS `isu_association_config`;
-DROP TABLE IF EXISTS `graph`;
 DROP TABLE IF EXISTS `isu_condition`;
 DROP TABLE IF EXISTS `isu`;
 DROP TABLE IF EXISTS `user`;


### PR DESCRIPTION
## やったこと
消去漏れのgraphテーブルの定義を削除

## 対応issue

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
