### PR TITLE
fix(ci): buildの際にsqlファイルをコピーしない

### DIFF
--- a/development/backend-go/ci.dockerfile
+++ b/development/backend-go/ci.dockerfile
@@ -10,9 +10,6 @@ RUN npm run build
 
 FROM golang:1.16.5-buster
 
-WORKDIR /webapp/sql
-COPY webapp/sql/ .
-
 WORKDIR /webapp/go
 
 #install mariadb-client

--- a/development/docker-compose-ci.yml
+++ b/development/docker-compose-ci.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - "../webapp/ec256-public.pem:/webapp/ec256-public.pem"
       - "../webapp/NoImage.png:/webapp/NoImage.png"
+      - "../webapp/sql:/webapp/sql"
     depends_on:
       - mysql-backend
 


### PR DESCRIPTION
## やったこと
buildの際にsqlファイルをコピーしない
## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
