### PR TITLE
feat(infra): ~isucon/webapp/sql/1_InitData.sql のみが root 権限で配置されているのを直した

### DIFF
--- a/provisioning/ansible/roles/contestant/tasks/isucondition.yml
+++ b/provisioning/ansible/roles/contestant/tasks/isucondition.yml
@@ -30,6 +30,9 @@
   copy:
     src: "initial-data.sql"
     dest: "/home/isucon/webapp/sql/1_InitData.sql"
+    owner: isucon
+    group: isucon
+    mode: "0644"
 
 - name: "roles.contestant.tasks.isucondition: Initialize isucondition Database"
   become_user: isucon


### PR DESCRIPTION
## やったこと

* ~isucon/webapp/sql/1_InitData.sql のみが root 権限で配置されているのを直した

## 対応issue

resolved #370

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
