### PR TITLE
feat(infra): 競技者 VM 起動時に jiaapi-mock を立ち上げるようにした

### DIFF
--- a/provisioning/ansible/roles/contestant/tasks/jiaapi_mock.yml
+++ b/provisioning/ansible/roles/contestant/tasks/jiaapi_mock.yml
@@ -33,6 +33,5 @@
   systemd:
     daemon_reload: "yes"
     name: "jiaapi-mock.service"
-    state: "stopped"
-    enabled: "no"
+    enabled: "yes"
 


### PR DESCRIPTION
## やったこと

- 競技者 VM 起動時に jiaapi-mock を立ち上げるようにした

## 対応issue

resolved #344

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
