### PR TITLE
feat(bench): bench の立ち上げる jiaapi のデフォルトポートを 5000 にした

### DIFF
--- a/bench/scenario/jiaapi.go
+++ b/bench/scenario/jiaapi.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -72,12 +71,17 @@ func (s *Scenario) JiaAPIService(ctx context.Context, step *isucandar.BenchmarkS
 	e.POST("/api/deactivate", postDeactivate)
 
 	// Start
-	serverPort := s.jiaServiceURL[strings.LastIndexAny(s.jiaServiceURL, ":"):] //":80"
+	var bindPort string
+	if s.jiaServiceURL.Port() != "" {
+		bindPort = fmt.Sprintf("0.0.0.0:%s", s.jiaServiceURL.Port())
+	} else {
+		bindPort = "0.0.0.0:80"
+	}
 	s.loadWaitGroup.Add(1)
 	go func() {
 		defer logger.AdminLogger.Println("--- ISU協会サービス END")
 		defer s.loadWaitGroup.Done()
-		err := e.Start(serverPort)
+		err := e.Start(bindPort)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			panic(fmt.Errorf("ISU協会サービスが異常終了しました: %v", err))
 		}

--- a/bench/scenario/prepare.go
+++ b/bench/scenario/prepare.go
@@ -50,7 +50,7 @@ func (s *Scenario) Prepare(ctx context.Context, step *isucandar.BenchmarkStep) e
 	}
 	initializer.Name = "benchmarker-initializer"
 
-	initResponse, errs := initializeAction(ctx, initializer, service.PostInitializeRequest{JIAServiceURL: s.jiaServiceURL})
+	initResponse, errs := initializeAction(ctx, initializer, service.PostInitializeRequest{JIAServiceURL: s.jiaServiceURL.String()})
 	for _, err := range errs {
 		step.AddError(err)
 	}

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -3,6 +3,7 @@ package scenario
 import (
 	"context"
 	"math"
+	"net/url"
 	"sync"
 	"time"
 
@@ -28,7 +29,7 @@ type Scenario struct {
 	realTimePrepareStartedAt time.Time     //Prepareの開始時間
 	virtualTimeStart         time.Time
 	virtualTimeMulti         time.Duration //時間が何倍速になっているか
-	jiaServiceURL            string
+	jiaServiceURL            *url.URL
 
 	// POST /initialize の猶予時間
 	initializeTimeout time.Duration
@@ -47,7 +48,7 @@ type Scenario struct {
 	Catalogs        map[string]*model.IsuCatalog
 }
 
-func NewScenario(jiaServiceURL string, loadTimeout time.Duration) (*Scenario, error) {
+func NewScenario(jiaServiceURL *url.URL, loadTimeout time.Duration) (*Scenario, error) {
 	return &Scenario{
 		// TODO: シナリオを初期化する
 		//realTimeStart: time.Now()


### PR DESCRIPTION
## やったこと

- bench の立ち上げる jiaapi のデフォルトポートを 5000 にした
- `--jia-service-url=http://apitest` のようにポートを指定しなかった場合 80 番ポートを利用するようにした
    - 本当は protocol を読んでよしなにデフォルトポートを変えるべき (例. https なら 443) だが、今回は横着した

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
