### PR TITLE
fix(infra): cleanup 処理で /root/.ssh 以下が削除されていないのを修正

### DIFF
--- a/provisioning/packer/base.libsonnet
+++ b/provisioning/packer/base.libsonnet
@@ -157,7 +157,7 @@
         'sudo apt remove -y ansible',
         'sudo apt-add-repository -y --remove ppa:ansible/ansible',
         'sudo rm -rf /etc/ansible',
-        'sudo rm -f /root/.ssh/*',
+        'sudo su -c "rm -rf /root/.ssh/*"',
       ],
     },
 


### PR DESCRIPTION
## やったこと

- cleanup 処理で /root/.ssh 以下が削除されていないのを修正

## 対応issue

resolved #419

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
