### PR TITLE
fix(backend): postIsuCondition のリクエストが空配列の場合 400 を返すようにした

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1328,6 +1328,9 @@ func postIsuCondition(c echo.Context) error {
 	if err != nil {
 		c.Logger().Errorf("bad request body: %v", err)
 		return c.String(http.StatusBadRequest, "bad request body")
+	} else if len(req) == 0 {
+		c.Logger().Errorf("bad request body: array length is 0")
+		return c.String(http.StatusBadRequest, "bad request body")
 	}
 
 	// トランザクション開始


### PR DESCRIPTION
## やったこと

-  postIsuCondition のリクエストが空配列の場合 400 を返すようにした

## 対応issue

resolved #354

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
