### PR TITLE
fix(ci): Change CI settings for golang at development directory

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,13 +5,19 @@ on:
     paths:
       - bench/**/*
       - webapp/go/**/*
-      - development/**/*
+      - development/backend-go/**/*
+      - development/docker-compose-ci.yml
+      - development/docker-compose-dev.yml
+      - development/Makefile
       - .github/workflows/go.yml
   pull_request:
     paths:
       - bench/**/*
       - webapp/go/**/*
-      - development/**/*
+      - development/backend-go/**/*
+      - development/docker-compose-ci.yml
+      - development/docker-compose-dev.yml
+      - development/Makefile
       - .github/workflows/go.yml
 
 jobs:


### PR DESCRIPTION
## やったこと

`development/` 配下の変更で動いていたCIをgolangに関わるところだけに変更

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
