### PR TITLE
[bench]: fix deadlock 

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -259,13 +259,25 @@ func main() {
 
 	b.AddScenario(s)
 
-	var sendResultMutex sync.Mutex
+	wg := sync.WaitGroup{}
 	b.Load(func(parent context.Context, step *isucandar.BenchmarkStep) error {
+		//このWaitGroupで、sendResult(,,true)が呼ばれた後sendResult(,,false)が呼ばれないことを保証する
+		//isucandarのparallelはcontextが終了した場合に、スレッドの終了を待たずにWaitを終了する
+		//そこで、wg.Done()が呼ばれsendResult(,,false)の送信を終了した後に、sendResult(,,true)の処理に移る
+		//
+		//コーナーケースとして、wg.Add(1)する前にb.Start(ctx)が終了しwg.Wait()を突破する可能性がある（loadの開始直後にCriticalErrorの場合など）
+		//その場合でも、この関数はctx.Done()を検出して早期returnすることでsendResult(,,false)を実行しないため、保証できている
+		//
+		//補足：
+		//　wg.Addをgoroutine内で呼ぶとこのコーナーケースを引き起こすので一般にはgoroutine生成直前にAddするべき
+		//　今回は生成直前がisucandar内にあり、そのタイミングでのAddが出来ないためここに記述
+		//　b.Startの前にAddする実装も考えたが、Prepareフェーズでstep.Cancel()された場合に、
+		//　Load自体がスキップされwg.Doneが実行されずにデッドロックを起こしたためボツ
+		wg.Add(1)
+		defer wg.Done()
 		if s.NoLoad {
 			return nil
 		}
-		sendResultMutex.Lock()
-		defer sendResultMutex.Unlock()
 
 		ctx, cancel := context.WithTimeout(parent, s.LoadTimeout)
 		defer cancel()
@@ -290,14 +302,8 @@ func main() {
 
 	result := b.Start(ctx)
 
-	//sendResult(,,ture)が呼ばれた後、sendResult(,,false)が呼ばれない説明
-	//prepareで失敗した場合 => b.Loadで登録した関数(途中経過送信関数)は呼ばれない
-	//loadに入った場合 => b.Startが終了しsendResult(,,ture)が呼ばれるのは、Loadが終了した後 or contextが終了した後
-	//    ・contextの終了の場合：途中経過送信関数が先にsendResultMutexを取って先に終了している or
-	//                           途中経過送信関数が後の場合はcontextチェックで終了するのでsendResult(,,false)は実行されない
-	//    ・contextの終了せず、Loadの終了の場合：b.Loadが先に終了しているのでsendResult(,,false)は実行されない
-	sendResultMutex.Lock()
-	defer sendResultMutex.Unlock()
+	wg.Wait()
+
 	if !sendResult(s, result, true) && exitStatusOnFail {
 		os.Exit(1)
 	}


### PR DESCRIPTION
## やったこと
prepareで失敗した場合にデッドロックするのを直した
## 対応issue
close #434
## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
