### PR TITLE
feat(ci): PR にて initial-data, jiaapi-mock Label が自動でつくようにした

### DIFF
--- a/.github/label-path-mapping.yml
+++ b/.github/label-path-mapping.yml
@@ -15,4 +15,8 @@ transplant:
   - webapp/python/**/*
   - webapp/ruby/**/*
   - webapp/rust/**/*
-
+initial-data:
+  - extra/initial-data/**/*
+  - bench/random/**/*
+jiaapi-mock:
+  - extra/jiaapi-mock/**/*


### PR DESCRIPTION
## やったこと

PR にて initla-data, jiaapi-mock Label が自動でつくようにした

## 対応issue

なし


## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
