### PR TITLE
fix(infra): Ansible で POST /initialize するのをやめた

### DIFF
--- a/provisioning/ansible/roles/contestant/tasks/isucondition.yml
+++ b/provisioning/ansible/roles/contestant/tasks/isucondition.yml
@@ -38,4 +38,3 @@
   become_user: isucon
   shell: |
     mysql -uisucon -pisucon -e 'CREATE DATABASE isucondition'
-    curl -f http://localhost/initialize -X POST -d '{"jia_service_url":"http://localhost:5000"}'


### PR DESCRIPTION
## やったこと

* Ansible で POST /initialize するのをやめた
    * TODO: その代わりに backend のプロセス起動時に POST /initialize 相当の処理を実行する必要がある → #503 で対応

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
