### PR TITLE
[bench]: シナリオ初期化失敗時にdeleteIsu

### DIFF
--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -489,7 +489,7 @@ func (s *Scenario) loadCompanyUser(ctx context.Context, step *isucandar.Benchmar
 		//並列にdeactivate
 		isuChan := make(chan *model.Isu, len(user.IsuListOrderByCreatedAt))
 		for _, isu := range user.IsuListOrderByCreatedAt {
-			go func() { isu.StreamsForScenario.StateChan <- model.IsuStateChangeDelete }()
+			go func(isu *model.Isu) { isu.StreamsForScenario.StateChan <- model.IsuStateChangeDelete }(isu)
 			isuChan <- isu
 		}
 		close(isuChan)


### PR DESCRIPTION
## やったこと

## 対応issue
close #507 
## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
前提 #506 

sleepしたときにwarnのpost Conditionの件数が増加する現象が防げていないが、わからないので別issueを立てる