### PR TITLE
fix(backend): Fix inconsistent error log for getIsuConditionsFromDB

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1115,7 +1115,7 @@ func getAllIsuConditions(c echo.Context) error {
 		conditionsTmp, err := getIsuConditionsFromDB(isu.JIAIsuUUID, cursorEndTime.Add(1*time.Second),
 			conditionLevel, startTime, limit+1, isu.Name)
 		if err != nil {
-			c.Logger().Errorf("failed to http request: %v", err)
+			c.Logger().Errorf("db error: %v", err)
 			return c.NoContent(http.StatusInternalServerError)
 		}
 


### PR DESCRIPTION
## やったこと
getIsuConditionsFromDB は2箇所から使われてエラーチェックされてるんですが、エラー時のログメッセージがずれていたので正しいと思われるほうに揃えました。
https://github.com/isucon/isucon11-qualify/blob/5653dae1f15bc2bd4fc7ba6c6ba1808e94471b57/webapp/go/main.go#L1115-L1120
https://github.com/isucon/isucon11-qualify/blob/5653dae1f15bc2bd4fc7ba6c6ba1808e94471b57/webapp/go/main.go#L1236-L1241

## 対応issue

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
