### PR TITLE
fix(backend) postIsuでのプレースホルダの?の数の間違いを修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -559,7 +559,7 @@ func postIsu(c echo.Context) error {
 
 	// 新しいisuのデータをinsert
 	_, err = db.Exec("INSERT INTO `isu`"+
-		"	(`jia_isu_uuid`, `name`, `image`, `character`, `jia_user_id`) VALUES (?, ?, ?, ?, ?, ?)",
+		"	(`jia_isu_uuid`, `name`, `image`, `character`, `jia_user_id`) VALUES (?, ?, ?, ?, ?)",
 		jiaIsuUUID, isuName, image, isuFromJIA.Character, jiaUserID)
 	if err != nil {
 		c.Logger().Errorf("db error: %v", err)


### PR DESCRIPTION
## やったこと
* postIsuでisuをinsertする部分で，プレースホルダの?の数が食い違ってしまっているバグがあったので，修正
  - カタログを消すPR #357  での修正漏れでした．すみません  

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
