### PR TITLE
fix(backend): getJIAServiceURLで受け渡されたtxを使うようにした

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -719,7 +719,7 @@ func deleteIsu(c echo.Context) error {
 	}
 
 	// JIAにisuのdeactivateをリクエスト
-	targetURL := getJIAServiceURL(nil) + "/api/deactivate"
+	targetURL := getJIAServiceURL(tx) + "/api/deactivate"
 	body := JIAServiceRequest{isuConditionPublicAddress, isuConditionPublicPort, jiaIsuUUID}
 	bodyJSON, err := json.Marshal(body)
 	if err != nil {


### PR DESCRIPTION
## やったこと
- `getJIAServiceURL`で受け渡された`tx`を使うようにした

## 対応issue
close #544 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
