### PR TITLE
jia-service-url を環境変数からも渡せるようにした

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -80,7 +80,7 @@ func init() {
 	flag.BoolVar(&showVersion, "version", false, "show version and exit 1")
 
 	var jiaServiceURLStr, timeoutDuration, initializeTimeoutDuration string
-	flag.StringVar(&jiaServiceURLStr, "jia-service-url", "http://apitest:5000", "jia service url")
+	flag.StringVar(&jiaServiceURLStr, "jia-service-url", getEnv("JIA_SERVICE_URL", "http://apitest:5000"), "jia service url")
 	flag.StringVar(&timeoutDuration, "timeout", "10s", "request timeout duration")
 	flag.StringVar(&initializeTimeoutDuration, "initialize-timeout", "20s", "request timeout duration of POST /initialize")
 


### PR DESCRIPTION
## やったこと

- jia-service-url を環境変数からも渡せるようにした
    - 本番の bench サーバでは supervisor より環境変数 `JIA_SERVICE_URL` で値が渡されるので

## 対応issue

なし

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
