### PR TITLE
feat(frontend): アップロード画像の対応拡張子にjpgを追加

### DIFF
--- a/webapp/frontend/src/components/UI/IconInput.tsx
+++ b/webapp/frontend/src/components/UI/IconInput.tsx
@@ -7,7 +7,7 @@ interface Props {
 const useImageSelect = (onSelect: (file: File) => void) => {
   const input = document.createElement('input')
   input.type = 'file'
-  input.accept = 'image/png,image/jpeg'
+  input.accept = 'image/jpeg'
 
   const onChange = () => {
     if (input.files && input.files[0]) {


### PR DESCRIPTION
## やったこと
IconInputでjpgも受け付けるようにした

## 対応issue
close #352 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
初期データなどにjpgが含まれているので一貫性のためにjpgは許容する必要がある