### PR TITLE
fix(bench) GET condition のバリデーションの修正

### DIFF
--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -128,7 +128,7 @@ func verifyIsuConditions(res *http.Response,
 		return errorInvalid(res, "要素数が正しくありません")
 	}
 	//レスポンス側のstartTimeのチェック
-	if request.StartTime != nil && len(backendData) != 0 && backendData[len(backendData)-1].Timestamp < *request.StartTime {
+	if request.StartTime != nil && len(backendData) != 0 && backendData[0].Timestamp < *request.StartTime {
 		return errorInvalid(res, "データが正しくありません")
 	}
 


### PR DESCRIPTION
## やったこと

GET condition で start_time を指定した時のバリデーションを以下のように修正

* 新: conditions 配列の最初の要素 (一番古いデータ) が start_time よりも古かったらエラー
* 旧: conditions 配列の最後の要素 (一番新しいデータ) が start_time よりも古かったらエラー

## 対応issue

なし

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
