### PR TITLE
fix(bench) isucondition の検証においてデータ損失を許すようにした

### DIFF
--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -138,7 +138,6 @@ scenarioLoop:
 		targetIsu := user.IsuListOrderByCreatedAt[nextTargetIsuIndex]
 
 		//GET /
-		mustExistUntil := s.ToVirtualTime(time.Now().Add(-1 * time.Second)).Unix()
 		dataExistTimestamp := GetConditionDataExistTimestamp(s, user)
 		_, _, errs := browserGetHomeAction(ctx, user.Agent, dataExistTimestamp, true,
 			func(res *http.Response, isuList []*service.Isu) []error {
@@ -150,12 +149,14 @@ scenarioLoop:
 			},
 			func(res *http.Response, conditions []*service.GetIsuConditionResponse) []error {
 				//conditionの検証
-				err := verifyIsuConditions(res, user, "", &service.GetIsuConditionRequest{
-					CursorEndTime:    dataExistTimestamp,
-					CursorJIAIsuUUID: "z",
-					ConditionLevel:   "critical,warning,info",
-				},
-					conditions, mustExistUntil,
+				err := verifyIsuConditions(
+					res, user, "",
+					&service.GetIsuConditionRequest{
+						CursorEndTime:    dataExistTimestamp,
+						CursorJIAIsuUUID: "z",
+						ConditionLevel:   "critical,warning,info",
+					},
+					conditions,
 				)
 				if err != nil {
 					return []error{err}
@@ -320,14 +321,11 @@ func (s *Scenario) getIsuConditionWithScroll(
 	scrollCount int,
 ) []*service.GetIsuConditionResponse {
 	//GET condition/{jia_isu_uuid} を取得してバリデーション
-	mustExistUntil := s.ToVirtualTime(time.Now().Add(-1 * time.Second)).Unix()
 	_, conditions, errs := browserGetIsuConditionAction(ctx, user.Agent, targetIsu.JIAIsuUUID,
 		request,
 		func(res *http.Response, conditions []*service.GetIsuConditionResponse) []error {
 			//conditionの検証
-			err := verifyIsuConditions(res, user, targetIsu.JIAIsuUUID, &request,
-				conditions, mustExistUntil,
-			)
+			err := verifyIsuConditions(res, user, targetIsu.JIAIsuUUID, &request, conditions)
 			if err != nil {
 				return []error{err}
 			}
@@ -361,9 +359,7 @@ func (s *Scenario) getIsuConditionWithScroll(
 			return nil
 		}
 		//検証
-		err = verifyIsuConditions(res, user, targetIsu.JIAIsuUUID, &request,
-			conditionsTmp, mustExistUntil,
-		)
+		err = verifyIsuConditions(res, user, targetIsu.JIAIsuUUID, &request, conditionsTmp)
 		if err != nil {
 			addErrorWithContext(ctx, step, err)
 			return nil
@@ -569,7 +565,6 @@ func (s *Scenario) loadCompanyUser(ctx context.Context, step *isucandar.Benchmar
 		}
 
 		//GET /
-		mustExistUntil := s.ToVirtualTime(time.Now().Add(-1 * time.Second)).Unix()
 		//TODO: ベンチはPUT isu/iconが来ないとして、304を常に許すようにします。
 		dataExistTimestamp := GetConditionDataExistTimestamp(s, user)
 		_, _, errs := browserGetHomeAction(ctx, user.Agent, dataExistTimestamp, true,
@@ -582,12 +577,14 @@ func (s *Scenario) loadCompanyUser(ctx context.Context, step *isucandar.Benchmar
 			},
 			func(res *http.Response, conditions []*service.GetIsuConditionResponse) []error {
 				//conditionの検証
-				err := verifyIsuConditions(res, user, "", &service.GetIsuConditionRequest{
-					CursorEndTime:    dataExistTimestamp,
-					CursorJIAIsuUUID: "z",
-					ConditionLevel:   "critical,warning,info",
-				},
-					conditions, mustExistUntil,
+				err := verifyIsuConditions(
+					res, user, "",
+					&service.GetIsuConditionRequest{
+						CursorEndTime:    dataExistTimestamp,
+						CursorJIAIsuUUID: "z",
+						ConditionLevel:   "critical,warning,info",
+					},
+					conditions,
 				)
 				if err != nil {
 					return []error{err}
@@ -696,7 +693,6 @@ func (s *Scenario) initCompanyUser(ctx context.Context, step *isucandar.Benchmar
 func (s *Scenario) checkCompanyConditionScenario(ctx context.Context, step *isucandar.BenchmarkStep, user *model.User, lastSolvedTime map[string]time.Time) bool {
 	//定期的にconditionを見に行くシナリオ
 	scenarioSuccess := true
-	mustExistUntil := s.ToVirtualTime(time.Now().Add(-1 * time.Second)).Unix()
 	dataExistTimestamp := GetConditionDataExistTimestamp(s, user)
 	request := service.GetIsuConditionRequest{
 		StartTime:        nil,
@@ -709,9 +705,7 @@ func (s *Scenario) checkCompanyConditionScenario(ctx context.Context, step *isuc
 		request,
 		func(res *http.Response, conditions []*service.GetIsuConditionResponse) []error {
 			//conditionの検証
-			err := verifyIsuConditions(res, user, "", &request,
-				conditions, mustExistUntil,
-			)
+			err := verifyIsuConditions(res, user, "", &request, conditions)
 			if err != nil {
 				return []error{err}
 			}
@@ -743,7 +737,7 @@ func (s *Scenario) checkCompanyConditionScenario(ctx context.Context, step *isuc
 			break
 		}
 		//検証
-		err = verifyIsuConditions(res, user, "", &request, conditionsTmp, mustExistUntil)
+		err = verifyIsuConditions(res, user, "", &request, conditionsTmp)
 		if err != nil {
 			scenarioSuccess = false
 			addErrorWithContext(ctx, step, err)

--- a/bench/scenario/prepare.go
+++ b/bench/scenario/prepare.go
@@ -5,15 +5,16 @@ package scenario
 
 import (
 	"context"
-	"fmt"
 	"crypto/md5"
-	"github.com/isucon/isucon11-qualify/bench/model"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/isucon/isucon11-qualify/bench/model"
 
 	"github.com/isucon/isucandar"
 	"github.com/isucon/isucandar/agent"
@@ -936,8 +937,7 @@ func (s *Scenario) prepareCheckGetIsuConditions(ctx context.Context, loginUser *
 		return
 	}
 	//検証 (TODO: これprepare用に正確な検証に変更する）
-	mustExistUntil := s.ToVirtualTime(time.Now()).Unix()
-	err = verifyIsuConditions(res, loginUser, isu.JIAIsuUUID, &req, conditionsTmp, mustExistUntil)
+	err = verifyIsuConditions(res, loginUser, isu.JIAIsuUUID, &req, conditionsTmp)
 	if err != nil {
 		step.AddError(err)
 		return


### PR DESCRIPTION
## やったこと

- isucondition の検証においてデータ損失を許すようにした
    - この話の前提に「そもそも点数設計を変え、 POST condition のタイムアウトを許す && GET condition で取得した conditions の件数分だけ加点する」という話があり、当 PR は `POST condition のタイムアウトを許す` の仕様に伴った GET 検証の実装更新
    - `POST condition のタイムアウトを許す` と `GET condition で取得した conditions の件数分だけ加点する` に関しては別 PR で実施

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
