### PR TITLE
fix(bench,infra) 開発環境用Makefileのtypoと思われる部分を修正

### DIFF
--- a/development/Makefile
+++ b/development/Makefile
@@ -8,20 +8,20 @@ down-go:
 
 .PHONY: up-bench
 up-bench:
-	target=go docker compose -f docker-compose-bench.yml up --build
+	target=go docker-compose -f docker-compose-bench.yml up --build
 
 .PHONY: run-bench
 run-bench:
-	target=go docker compose -f docker-compose-bench.yml exec apitest go run ./main.go
+	target=go docker-compose -f docker-compose-bench.yml exec apitest go run ./main.go
 
 .PHONY: run-bench-race
 run-bench-race:
-	target=go docker compose -f docker-compose-bench.yml exec apitest go run -race ./main.go
+	target=go docker-compose -f docker-compose-bench.yml exec apitest go run -race ./main.go
 
 .PHONY: down-bench
 down-bench:
-	target=go docker compose -f docker-compose-bench.yml down
+	target=go docker-compose -f docker-compose-bench.yml down
 
 .PHONY: run-bench-noload
 run-bench-noload:
-	target=go docker compose -f docker-compose-bench.yml exec apitest go run ./main.go --no-load=true
+	target=go docker-compose -f docker-compose-bench.yml exec apitest go run ./main.go --no-load=true


### PR DESCRIPTION
## やったこと
* 開発環境用Makefileで `docker-compose`  ではなく `docker compose` と書かれており，typoかと思ったので修正

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
* 自分の知らない記法なのかもしれないので，間違ってたら教えてくださいmm