### PR TITLE
fix(sql): Add unique to jia_isu_uuid

### DIFF
--- a/webapp/sql/0_Schema.sql
+++ b/webapp/sql/0_Schema.sql
@@ -7,7 +7,7 @@ DROP TABLE IF EXISTS `user`;
 
 CREATE TABLE `isu` (
   `id` bigint AUTO_INCREMENT,
-  `jia_isu_uuid` CHAR(36) NOT NULL,
+  `jia_isu_uuid` CHAR(36) NOT NULL UNIQUE,
   `name` VARCHAR(255) NOT NULL,
   `image` LONGBLOB,
   `character` VARCHAR(255),


### PR DESCRIPTION
## やったこと

isu テーブルの jia_isu_uuidにユニーク制約を付与

- 無いとjia_isu_uuidの重複や多重登録が起きてしまう

## 対応issue

#456 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考

```
apitest_1        | ⇨ http server started on [::]:5000
apitest_1        | 01:18:43.258939 ERR: prepare: status code: 期待する HTTP ステータスコード以外が返却されました (expected: 409): 403 (POST: /api/isu)
```