### PR TITLE
fix(backend) getGraphで根拠のtimestampを返す部分のバグを修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -767,6 +767,7 @@ func generateIsuGraphResponse(tx *sqlx.Tx, jiaIsuUUID string, graphDate time.Tim
 
 			startTimeInThisHour = truncatedConditionTime
 			conditionsInThisHour = []IsuCondition{}
+			timestampsInThisHour = []int64{}
 		}
 		conditionsInThisHour = append(conditionsInThisHour, condition)
 		timestampsInThisHour = append(timestampsInThisHour, condition.Timestamp.Unix())


### PR DESCRIPTION
## やったこと
* graphの根拠となるtimestampを準備する部分で，バグを見つけたので修正
  - timpestampを入れておくsliceをリフレッシュする処理を忘れていたので，追加

## 対応issue
* #655 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
* 他にもバグがあるかもですが，一旦コレで直ってそうか確認してもらえるとありがたいです！