### PR TITLE
fix(backend): Avoid ONLY_FULL_GROUP_BY

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1219,7 +1219,7 @@ func truncateAfterHours(t time.Time) time.Time {
 // ISUの性格毎の最新のコンディション情報
 func getTrend(c echo.Context) error {
 	characterList := []Isu{}
-	err := db.Select(&characterList, "SELECT * FROM `isu` GROUP BY `character`")
+	err := db.Select(&characterList, "SELECT `character` FROM `isu` GROUP BY `character`")
 	if err != nil {
 		c.Logger().Errorf("db error: %v", err)
 		return c.NoContent(http.StatusInternalServerError)


### PR DESCRIPTION
## やったこと

ONLY_FULL_GROUP_BY が有効の際にエラーとなるSQLの修正

## 対応issue

close: #684

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
