### PR TITLE
fix(backend) getIsuにおいて，isu_conditionが0件のとき，latest_isu_conditionでnullを返すようにする

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -671,14 +671,14 @@ func getIsu(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	conditionLevel, err := calcConditionLevel(lastCondition.Condition)
-	if err != nil {
-		c.Logger().Errorf("failed to get condition level: %v", err)
-		return c.NoContent(http.StatusInternalServerError)
-	}
-
 	var formatedCondition *GetIsuConditionResponse
 	if foundLastCondition {
+		conditionLevel, err := calcConditionLevel(lastCondition.Condition)
+		if err != nil {
+			c.Logger().Errorf("failed to get condition level: %v", err)
+			return c.NoContent(http.StatusInternalServerError)
+		}
+
 		formatedCondition = &GetIsuConditionResponse{
 			JIAIsuUUID:     lastCondition.JIAIsuUUID,
 			IsuName:        isu.Name,


### PR DESCRIPTION
## やったこと
* geIsuにおいて，isu_conditionが0件のとき，latest_isu_conditionでnullを返すようにする
  - 現状はゼロ値の構造体（の値）が返ってしまっている

## 対応issue
* #672 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
