### PR TITLE
[initial data]initial-data生成時のtimezoneを固定

### DIFF
--- a/extra/initial-data/generate.go
+++ b/extra/initial-data/generate.go
@@ -18,6 +18,8 @@ const (
 )
 
 func init() {
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	time.Local = loc
 	t, _ := time.Parse(time.RFC3339, "2021-07-01T00:00:00+07:00")
 	rand.Seed(t.UnixNano())
 	uuid.SetRand(rand.New(rand.NewSource(t.UnixNano())))

--- a/extra/initial-data/models/json.go
+++ b/extra/initial-data/models/json.go
@@ -69,10 +69,7 @@ type JsonCondition struct {
 
 func (j *JsonConditions) AddCondition(condition Condition, isuId int) error {
 	jsonCondition := JsonCondition{
-		// JST分マイナスすると何故かちょうどよい
-		// DB上はJSTなのでUnixtimeはJST時間に変換されている（UTC時間+9表記）
-		// JST時間なのにどこかでTimezone情報なくなって時刻表記だけになる→UTCとして解釈される→JST環境では更に+9時間されて本来より9時間多い値になるとか？
-		condition.Timestamp.Add(-9 * time.Hour).Unix(),
+		condition.Timestamp.Unix(),
 		condition.IsSitting,
 		condition.IsDirty,
 		condition.IsOverweight,


### PR DESCRIPTION
## やったこと
generate.goのtimezoneが実行環境でかわるのでAsia/Tokyoに固定しました。

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
