### PR TITLE
[bench] isuListからpageとlimitがなくなったので追従

### DIFF
--- a/bench/scenario/action.go
+++ b/bench/scenario/action.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/isucon/isucandar/agent"
@@ -285,19 +284,11 @@ func getMeErrorAction(ctx context.Context, a *agent.Agent) (string, *http.Respon
 	return resBody, res, nil
 }
 
-func getIsuAction(ctx context.Context, a *agent.Agent, limit int) ([]*service.Isu, *http.Response, error) {
+func getIsuAction(ctx context.Context, a *agent.Agent) ([]*service.Isu, *http.Response, error) {
 	targetURL, err := url.Parse("/api/isu")
 	if err != nil {
 		logger.AdminLogger.Panicln(err)
 	}
-	q := url.Values{}
-	if limit < 0 {
-		logger.AdminLogger.Panicf("internal error: limit is minus: %v\n", limit)
-	}
-	if limit != 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	targetURL.RawQuery = q.Encode()
 
 	var isuList []*service.Isu
 	res, err := reqJSONResJSON(ctx, a, http.MethodGet, targetURL.String(), nil, &isuList, []int{http.StatusOK})
@@ -307,9 +298,13 @@ func getIsuAction(ctx context.Context, a *agent.Agent, limit int) ([]*service.Is
 	return isuList, res, nil
 }
 
-func getIsuErrorAction(ctx context.Context, a *agent.Agent, query url.Values) (string, *http.Response, error) {
-	rpath := getPathWithParams("/api/isu", query)
-	res, resBody, err := reqJSONResError(ctx, a, http.MethodGet, rpath, nil, []int{http.StatusUnauthorized, http.StatusBadRequest})
+func getIsuErrorAction(ctx context.Context, a *agent.Agent) (string, *http.Response, error) {
+	targetURL, err := url.Parse("/api/isu")
+	if err != nil {
+		logger.AdminLogger.Panicln(err)
+	}
+
+	res, resBody, err := reqJSONResError(ctx, a, http.MethodGet, targetURL.String(), nil, []int{http.StatusUnauthorized, http.StatusBadRequest})
 	if err != nil {
 		return "", nil, err
 	}
@@ -612,7 +607,7 @@ func browserGetHomeAction(ctx context.Context, a *agent.Agent,
 
 	errors := []error{}
 	// TODO: ここ以下は多分並列
-	isuList, hres, err := getIsuAction(ctx, a, homeIsuLimit)
+	isuList, hres, err := getIsuAction(ctx, a)
 	if err != nil {
 		errors = append(errors, err)
 	}

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -141,9 +141,6 @@ func (s *Scenario) loadNormalUser(ctx context.Context, step *isucandar.Benchmark
 				// poster で送ったものの同期
 				user.GetConditionFromChan(ctx)
 				expected := user.IsuListOrderByCreatedAt
-				if homeIsuLimit < len(expected) { //limit
-					expected = expected[len(expected)-homeIsuLimit:]
-				}
 				return verifyIsuOrderByCreatedAt(res, expected, isuList)
 			},
 		)
@@ -200,7 +197,7 @@ func (s *Scenario) loadViewer(ctx context.Context, step *isucandar.BenchmarkStep
 		default:
 		}
 		logger.AdminLogger.Println("viewer load")
-	
+
 		// trends, err := getTrendAction()
 		// updatedTimestampCount, err := verifyTrend(trends)
 	}
@@ -416,7 +413,7 @@ func (s *Scenario) getIsuConditionUntilAlreadyRead(
 
 		// ConditionPagingStep ページごとに現状の condition をスコアリング
 		pagingCount++
-		if pagingCount % ConditionPagingStep == 0 {
+		if pagingCount%ConditionPagingStep == 0 {
 			for _, cond := range conditions {
 				addConditionScoreTag(cond, step)
 			}

--- a/bench/scenario/prepare.go
+++ b/bench/scenario/prepare.go
@@ -278,7 +278,7 @@ func (s *Scenario) prepareCheckGetMe(ctx context.Context, loginUser *model.User,
 func (s *Scenario) prepareCheckGetIsuList(ctx context.Context, loginUser *model.User, noIsuUser *model.User, guestAgent *agent.Agent, step *isucandar.BenchmarkStep) {
 	//ISU一覧の取得 e.GET("/api/isu", getIsuList)
 	// check: 椅子未所持の場合は椅子が存在しない
-	isuList, res, err := getIsuAction(ctx, noIsuUser.Agent, 1)
+	isuList, res, err := getIsuAction(ctx, noIsuUser.Agent)
 	if err != nil {
 		step.AddError(err)
 		return
@@ -288,11 +288,11 @@ func (s *Scenario) prepareCheckGetIsuList(ctx context.Context, loginUser *model.
 		return
 	}
 
-	// check: 登録したISUがlimit分取得できる
+	// check: 登録したISUが取得できる
 	isu1 := loginUser.IsuListOrderByCreatedAt[0]
 	isu2 := loginUser.IsuListOrderByCreatedAt[1]
 	expected := []*model.Isu{isu2, isu1}
-	isuList, res, err = getIsuAction(ctx, loginUser.Agent, 2)
+	isuList, res, err = getIsuAction(ctx, loginUser.Agent)
 	if err != nil {
 		step.AddError(err)
 		return
@@ -314,47 +314,12 @@ func (s *Scenario) prepareCheckGetIsuList(ctx context.Context, loginUser *model.
 	}
 
 	// check: サインインしてない状態で取得
-	query := url.Values{}
-	resBody, res, err := getIsuErrorAction(ctx, guestAgent, query)
+	resBody, res, err := getIsuErrorAction(ctx, guestAgent)
 	if err != nil {
 		step.AddError(err)
 		return
 	}
 	if err := verifyNotSignedIn(res, resBody); err != nil {
-		step.AddError(err)
-		return
-	}
-
-	// check: limitが不正(0)
-	query = url.Values{}
-	query.Set("limit", "0")
-	resBody, res, err = getIsuErrorAction(ctx, loginUser.Agent, query)
-	if err != nil {
-		step.AddError(err)
-		return
-	}
-	if err := verifyStatusCode(res, http.StatusBadRequest); err != nil {
-		step.AddError(err)
-		return
-	}
-	if err := verifyText(res, resBody, "bad format: limit"); err != nil {
-		step.AddError(err)
-		return
-	}
-
-	// check: limitが不正(文字列)
-	query = url.Values{}
-	query.Set("limit", "limit")
-	resBody, res, err = getIsuErrorAction(ctx, loginUser.Agent, query)
-	if err != nil {
-		step.AddError(err)
-		return
-	}
-	if err := verifyStatusCode(res, http.StatusBadRequest); err != nil {
-		step.AddError(err)
-		return
-	}
-	if err := verifyText(res, resBody, "bad format: limit"); err != nil {
 		step.AddError(err)
 		return
 	}


### PR DESCRIPTION
## やったこと
backendのisuListからpageとlimitがなくなったので追従

## 対応issue
https://github.com/isucon/isucon11-qualify/pull/716 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
