### PR TITLE
feat(jiaapi-mock) postingしているISUを全停止するエンドポイントを追加

### DIFF
--- a/extra/jiaapi-mock/controller/activation.go
+++ b/extra/jiaapi-mock/controller/activation.go
@@ -131,6 +131,18 @@ func (c *ActivationController) PostDeactivate(ctx echo.Context) error {
 	return ctx.NoContent(http.StatusNoContent)
 }
 
+func (c *ActivationController) GetStopAll(ctx echo.Context) error {
+	fmt.Println("hello!!! from get test")
+
+	err := c.isuConditionPosterManager.StopPostingAll()
+	if err != nil {
+		ctx.Logger().Errorf("failed to stopPostingAll: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	return ctx.String(http.StatusOK, "ok")
+}
+
 func isPrivateIP(ipstr string) bool {
 
 	ipAddr, err := net.ResolveIPAddr("ip", ipstr)

--- a/extra/jiaapi-mock/main.go
+++ b/extra/jiaapi-mock/main.go
@@ -43,6 +43,7 @@ func main() {
 	e.GET("/api/catalog/:catalog_id", catalogController.GetCatalog)
 	e.POST("/api/activate", activationController.PostActivate)
 	e.POST("/api/deactivate", activationController.PostDeactivate)
+	e.GET("/api/stop_all", activationController.GetStopAll)
 	e.POST("/api/die", func(ctx echo.Context) error {
 		input := &struct {
 			Password string `json:"password" validate:"required"`

--- a/extra/jiaapi-mock/model/isu_poster_manager.go
+++ b/extra/jiaapi-mock/model/isu_poster_manager.go
@@ -45,3 +45,17 @@ func (m *IsuConditionPosterManager) StopPosting(targetIp string, targetPort int,
 	}
 	return nil
 }
+
+func (m *IsuConditionPosterManager) StopPostingAll() error {
+	m.activatedIsuMtx.Lock()
+	defer m.activatedIsuMtx.Unlock()
+
+	for key := range m.activatedIsu {
+		isu, ok := m.activatedIsu[key]
+		if ok {
+			isu.StopPosting()
+			delete(m.activatedIsu, key)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## やったこと
* postingしているISUを全停止するエンドポイント `GET <jiaapi-mock>/api/stop_all` を追加

## 対応issue
* #594 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
