### PR TITLE
[bench]: 即returnでもPostContentNum一杯postする

### DIFF
--- a/bench/scenario/posting.go
+++ b/bench/scenario/posting.go
@@ -15,7 +15,7 @@ import (
 const (
 	// MEMO: 最大でも一秒に一件しか送れないので点数上限になるが、解決できるとは思えないので良い
 	PostIntervalSecond = 60 //Virtual Timeでのpost間隔
-	PostContentNum     = 10 //一回のpostで何要素postするか
+	PostContentNum     = 10 //一回のpostで何要素postするか virtualTimeMulti * timerDuration(20ms) / PostIntervalSecond
 )
 
 type posterState struct {


### PR DESCRIPTION
## やったこと

競技者が即post conditionを落とすよりも、sleep(50ms)した方が、次のリクエストが一杯詰まっていてbulk insertがしやすくて嬉しい

みたいなことを出来ないようにする。

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
