### PR TITLE
feat(backend): セッションに紐づくユーザーの存在確認をするようにした

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -290,11 +290,25 @@ func getUserIDFromSession(c echo.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	userID, ok := session.Values["jia_user_id"]
+	_jiaUserID, ok := session.Values["jia_user_id"]
 	if !ok {
 		return "", fmt.Errorf("no session")
 	}
-	return userID.(string), nil
+
+	jiaUserID := _jiaUserID.(string)
+	var count int
+
+	err = db.Get(&count, "SELECT COUNT(*) FROM `user` WHERE `jia_user_id` = ?",
+		jiaUserID)
+	if err != nil {
+		return "", err
+	}
+
+	if count == 0 {
+		return "", fmt.Errorf("not found: user")
+	}
+
+	return jiaUserID, nil
 }
 
 func getJIAServiceURL(tx *sqlx.Tx) string {


### PR DESCRIPTION
## やったこと
`getUserIDFromSession`内でユーザーの存在確認のSQLクエリを発行するようにした

## 対応issue
close #536

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
