### PR TITLE
fix(backend): getUserIDFromSession内でdb errorが発生した時に500が返るようにした

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -417,10 +417,10 @@ func postSignout(c echo.Context) error {
 	if err != nil {
 		if errStatusCode == http.StatusUnauthorized {
 			return c.String(http.StatusUnauthorized, "you are not signed in")
-		} else {
-			c.Logger().Errorf("failed to getUserIDFromSession: %v", err)
-			return c.NoContent(http.StatusInternalServerError)
 		}
+
+		c.Logger().Errorf("failed to getUserIDFromSession: %v", err)
+		return c.NoContent(http.StatusInternalServerError)
 	}
 
 	session, err := getSession(c.Request())


### PR DESCRIPTION
## やったこと
getUserIDFromSession内でエラー発生時にhttp status codeの種類を返すようにした

## 対応issue
close #870

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
