### PR TITLE
[bench]: fix ReadConditionCount atomic

### DIFF
--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -79,7 +79,11 @@ func (s *Scenario) Load(parent context.Context, step *isucandar.BenchmarkStep) e
 	s.loadWaitGroup.Wait()
 
 	// 余りの加点
-	addConditionScoreTag(step, &ReadConditionCount{Info: readInfoConditionFraction, Warn: readWarnConditionFraction, Critical: readCriticalConditionFraction})
+	addConditionScoreTag(step, &ReadConditionCount{
+		Info:     atomic.LoadInt32(&readInfoConditionFraction),
+		Warn:     atomic.LoadInt32(&readWarnConditionFraction),
+		Critical: atomic.LoadInt32(&readCriticalConditionFraction),
+	})
 
 	return nil
 }


### PR DESCRIPTION
## やったこと
atomicが間違っていたのを修正

viewUpdatedTrendCounterもばぐってるけど、それは #868 で直す
## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
s.loadWaitGroup.Wait しているので大丈夫と言えば大丈夫なんですが、混乱は招くので