### PR TITLE
fix(backend) JIA APIからのエラーメッセージをログに表示するようにした

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -608,7 +608,13 @@ func postIsu(c echo.Context) error {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusAccepted {
-		c.Logger().Errorf("JIAService returned error: status code %v", res.StatusCode)
+		resBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			c.Logger().Errorf("error occurred while reading JIA response: %v", err)
+			return c.NoContent(http.StatusInternalServerError)
+		}
+
+		c.Logger().Errorf("JIAService returned error: status code %v, message: %v", res.StatusCode, string(resBody))
 		return c.String(res.StatusCode, "JIAService returned error")
 	}
 


### PR DESCRIPTION
## やったこと
* JIA APIからのエラーメッセージをログに表示するようにした

## 対応issue
* #887 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
* 現状JIA APIからはjsonが返って来ているので，そちらは以下のissueで対応します
  * #917 