### PR TITLE
[initial-data] isu情報更新されないバグ修正

### DIFF
--- a/extra/initial-data/models/isu.go
+++ b/extra/initial-data/models/isu.go
@@ -66,12 +66,12 @@ func defaultImage() []byte {
 	return bytes
 }
 
-func (i Isu) WithUpdateName() error {
+func (i *Isu) WithUpdateName() error {
 	i.Name = random.IsuName()
 	i.UpdatedAt = random.TimeAfterArg(i.UpdatedAt)
 	return nil
 }
-func (i Isu) WithUpdateImage() error {
+func (i *Isu) WithUpdateImage() error {
 	var err error
 	i.Image, err = random.Image()
 	i.UpdatedAt = random.TimeAfterArg(i.UpdatedAt)


### PR DESCRIPTION
## やったこと
initial data作成時にisu情報更新されなくなっていたので修正

## 対応issue
https://github.com/isucon/isucon11-qualify/issues/904

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
