### PR TITLE
feat(backend): エラーログの記法を統一

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -796,7 +796,7 @@ func generateIsuGraphResponse(tx *sqlx.Tx, jiaIsuUUID string, graphDate time.Tim
 
 	rows, err := tx.Queryx("SELECT * FROM `isu_condition` WHERE `jia_isu_uuid` = ? ORDER BY `timestamp` ASC", jiaIsuUUID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("db error: %v", err)
 	}
 
 	for rows.Next() {
@@ -1033,7 +1033,7 @@ func getIsuConditionsFromDB(db *sqlx.DB, jiaIsuUUID string, endTime time.Time, c
 		)
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("db error: %v", err)
 	}
 
 	conditionsResponse := []*GetIsuConditionResponse{}


### PR DESCRIPTION
## やったこと
アプリケーションの起動に関わるエラーについては丁寧に出力する
db実行によるエラーは`Errorf("db error: %v", err)`で統一
関数からエラーが返ってきた場合は基本的にそのまま出力

## 対応issue
close #579 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
