### PR TITLE
[initial-data] メッセージ内容が更新されるように修正

### DIFF
--- a/extra/initial-data/models/condition.go
+++ b/extra/initial-data/models/condition.go
@@ -48,6 +48,7 @@ func NewConditionFromLastCondition(c Condition, durationMinute int) Condition {
 	c.IsDirty = random.IsDirtyFromLastCondition(c.IsDirty)
 	c.IsOverweight = random.IsOverweightFromLastCondition(c.IsOverweight)
 	c.IsBroken = random.IsBrokenFromLastCondition(c.IsBroken)
+	c.Message = random.MessageWithCondition(c.IsDirty, c.IsOverweight, c.IsBroken, c.Isu.CharacterId)
 	return c
 }
 


### PR DESCRIPTION
## やったこと
* messageの生成が実装されたが、intialデータ生成時は初期状態のmessageしか設定されてなかったので修正

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
