### PR TITLE
fix(backend) trendAPIのヒントのTODOコメントを削除

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1095,7 +1095,6 @@ func getTrend(c echo.Context) error {
 
 	res := []TrendResponse{}
 
-	// TODO: 処理が重すぎるのでなんとかする
 	for _, character := range characterList {
 		isuList := []Isu{}
 		err = db.Select(&isuList,


### PR DESCRIPTION
## やったこと
trend APIにあった 
```
// TODO: 処理が重すぎるのでなんとかする
```
というヒントのコメントを削除しました．

意図としては，
このボトルネックは計測すればわかり，意図的に処理を落とすような変なこともしていので，
他のボトルネックと揃えてヒントコメントが無いほうがいいんじゃないかな，と思った感じです．

何かあればコメントいただけるとありがたいです

## 対応issue
なし

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
