### PR TITLE
fix(backend) 関数毎のコメントにおけるエンドポイントのURLの表記を変更

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -672,7 +672,7 @@ func postIsu(c echo.Context) error {
 	return c.JSON(http.StatusCreated, isu)
 }
 
-// GET /api/isu/{jia_isu_uuid}
+// GET /api/isu/:jia_isu_uuid
 // ISUの情報を取得
 func getIsuID(c echo.Context) error {
 	jiaUserID, errStatusCode, err := getUserIDFromSession(c)
@@ -702,7 +702,7 @@ func getIsuID(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
-// GET /api/isu/{jia_isu_uuid}/icon
+// GET /api/isu/:jia_isu_uuid/icon
 // ISUのアイコンを取得
 func getIsuIcon(c echo.Context) error {
 	jiaUserID, errStatusCode, err := getUserIDFromSession(c)
@@ -732,7 +732,7 @@ func getIsuIcon(c echo.Context) error {
 	return c.Blob(http.StatusOK, "", image)
 }
 
-// GET /api/isu/{jia_isu_uuid}/graph
+// GET /api/isu/:jia_isu_uuid/graph
 // ISUのコンディショングラフ描画のための情報を取得
 func getIsuGraph(c echo.Context) error {
 	jiaUserID, errStatusCode, err := getUserIDFromSession(c)
@@ -941,7 +941,7 @@ func calculateGraphDataPoint(isuConditions []IsuCondition) GraphDataPoint {
 	return dataPoint
 }
 
-// GET /api/condition/{jia_isu_uuid}
+// GET /api/condition/:jia_isu_uuid
 // ISUのコンディションを取得
 func getIsuConditions(c echo.Context) error {
 	jiaUserID, errStatusCode, err := getUserIDFromSession(c)
@@ -1149,7 +1149,7 @@ func getTrend(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
-// POST /api/condition/{jia_isu_uuid}
+// POST /api/condition/:jia_isu_uuid
 // ISUからのコンディションを受け取る
 func postIsuCondition(c echo.Context) error {
 	// TODO: 一定割合リクエストを落としてしのぐようにしたが、本来は全量さばけるようにすべき


### PR DESCRIPTION
## やったこと
* 関数毎のコメントで，エンドポイントのURL表記を `GET /api/isu/{isu_uuid}` から `GET /api/isu/:isu_uuid` に変えた

## 対応issue
* #947 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
