### PR TITLE
fix(backend) getIsuConditionsでlimitパラメータを受け取るのをやめるようにした

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -997,7 +997,7 @@ func getIsuConditions(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	conditionsResponse, err := getIsuConditionsFromDB(db, jiaIsuUUID, endTime, conditionLevel, startTime, isuName)
+	conditionsResponse, err := getIsuConditionsFromDB(db, jiaIsuUUID, endTime, conditionLevel, startTime, conditionLimit, isuName)
 	if err != nil {
 		c.Logger().Errorf("db error: %v", err)
 		return c.NoContent(http.StatusInternalServerError)


### PR DESCRIPTION
## やったこと
* getIsuConditionsでlimitパラメータを受け取るのをやめるようにした
* getIsuConditionsFromDBを呼ぶ時は，引数のlimitに定数(=20件)を渡すようにした

## 対応issue
* #955 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考