### PR TITLE
[backend] GET /api/trend のレスポンス修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1131,7 +1131,12 @@ func getTrend(c echo.Context) error {
 			return characterCriticalIsuConditions[i].Timestamp > characterCriticalIsuConditions[j].Timestamp
 		})
 		res = append(res,
-			TrendResponse{Character: character.Character, Info: characterInfoIsuConditions, Warning: characterWarningIsuConditions, Critical: characterCriticalIsuConditions})
+			TrendResponse{
+				Character: character.Character,
+				Info:      characterInfoIsuConditions,
+				Warning:   characterWarningIsuConditions,
+				Critical:  characterCriticalIsuConditions,
+			})
 	}
 
 	return c.JSON(http.StatusOK, res)


### PR DESCRIPTION
## やったこと
レスポンスボディの修正をしました
背景としてレスポンスがでかすぎるせいで bench の decodeでCPUをめちゃくちゃ食べたり、network大丈夫？みたいな話があったりしました
before
```
[
{ character: "hoge", conditions: [ { isu_id: 0, condition: "info", timestamp: 0 }, ...  ] }
...
]
```
after
```
[
{ character: "hoge", info: [ { isu_id: 0, timestamp: 0 }, ...  ], warning: [ { isu_id: 0, timestamp: 0 }, ... ], critical: [  { isu_id: 0, timestamp: 0 }, ... ] }
...
]
```

## 対応issue
ref: #924


## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
