### PR TITLE
feat(backend): docker-compose-*.ymlの環境変数名を修正

### DIFF
--- a/development/docker-compose-bench.yml
+++ b/development/docker-compose-bench.yml
@@ -33,9 +33,9 @@ services:
       dockerfile: mysql-backend/Dockerfile
     restart: always
     environment:
-      MYSQL_DBNAME: isucondition
+      MYSQL_DATABASE: isucondition
       MYSQL_USER: isucon
-      MYSQL_PASS: isucon
+      MYSQL_PASSWORD: isucon
       MYSQL_ROOT_PASSWORD: root
     volumes:
       # 開発環境用のものを使って初期化

--- a/development/docker-compose-ci.yml
+++ b/development/docker-compose-ci.yml
@@ -26,9 +26,9 @@ services:
       dockerfile: mysql-backend/Dockerfile
     restart: always
     environment:
-      MYSQL_DBNAME: isucondition
+      MYSQL_DATABASE: isucondition
       MYSQL_USER: isucon
-      MYSQL_PASS: isucon
+      MYSQL_PASSWORD: isucon
       MYSQL_ROOT_PASSWORD: root
     volumes:
       - "../webapp/sql/0_Schema.sql:/docker-entrypoint-initdb.d/0_Schema.sql"

--- a/development/docker-compose-dev.yml
+++ b/development/docker-compose-dev.yml
@@ -36,9 +36,9 @@ services:
       dockerfile: mysql-backend/Dockerfile
     restart: always
     environment:
-      MYSQL_DBNAME: isucondition
+      MYSQL_DATABASE: isucondition
       MYSQL_USER: isucon
-      MYSQL_PASS: isucon
+      MYSQL_PASSWORD: isucon
       MYSQL_ROOT_PASSWORD: root
     volumes:
       # 開発環境用のものを使って初期化


### PR DESCRIPTION
## やったこと
環境変数名をGoの実装とAWSの環境変数名に合わせた
https://github.com/isucon/isucon11-qualify/blob/8e1af163627017184c81ee04c5c02234a5043834/provisioning/ansible/roles/contestant/files/var/lib/cloud/scripts/per-instance/generate-env_aws.sh

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
