### PR TITLE
fix(jiaapi-mock) JIA APIモックが送ってくるメッセージを変更

### DIFF
--- a/extra/jiaapi-mock/model/isu_poster.go
+++ b/extra/jiaapi-mock/model/isu_poster.go
@@ -52,7 +52,7 @@ func (m *IsuConditionPoster) KeepPosting() {
 				(randEngine.Intn(2) == 0),
 				(randEngine.Intn(2) == 0),
 			),
-			Message:   "今日もいい天気",
+			Message:   "テストメッセージです",
 			Timestamp: nowTime.Unix(),
 		}})
 		if err != nil {


### PR DESCRIPTION
## やったこと
* JIA APIが送ってくるメッセージを必要十分な情報のもの（テストメッセージです）に変更
  * https://isucon.slack.com/archives/C021YD1HXUL/p1628565852441100?thread_ts=1628561768.435600&cid=C021YD1HXUL

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
