### PR TITLE
feat(jiaapi-mock) ポート番号のない URL を許すようにした

### DIFF
--- a/extra/jiaapi-mock/controller/activation.go
+++ b/extra/jiaapi-mock/controller/activation.go
@@ -3,8 +3,6 @@ package controller
 import (
 	"net/http"
 	"net/url"
-	"strconv"
-	"strings"
 
 	"github.com/isucon/isucon11-qualify/jiaapi-mock/model"
 	"github.com/labstack/echo/v4"
@@ -80,29 +78,13 @@ func (c *ActivationController) PostActivate(ctx echo.Context) error {
 		return ctx.String(http.StatusBadRequest, "Bad URL")
 	}
 
-	split := strings.Split(parsedURL.Host, ":")
-	if len(split) != 2 {
-		ctx.Logger().Errorf("bad url")
-		return ctx.String(http.StatusBadRequest, "Bad URL")
-	}
-	port, err := strconv.Atoi(split[1])
-	if err != nil {
-		ctx.Logger().Errorf("bad port: %v", err)
-		return ctx.String(http.StatusBadRequest, "Bad port")
-	}
-
-	if !(0 <= port && port < 0x1000) {
-		ctx.Logger().Errorf("bad port: %v", port)
-		return ctx.String(http.StatusBadRequest, "Bad port")
-	}
-
 	isuState, ok := validIsu[req.IsuUUID]
 	if !ok {
 		ctx.Logger().Errorf("bad isu_uuid: %v", req.IsuUUID)
 		return ctx.String(http.StatusNotFound, "Bad isu_uuid")
 	}
 
-	err = c.isuConditionPosterManager.StartPosting(req.TargetBaseURL, req.IsuUUID)
+	err = c.isuConditionPosterManager.StartPosting(parsedURL, req.IsuUUID)
 	if err != nil {
 		ctx.Logger().Errorf("failed to startPosting: %v", err)
 		return ctx.NoContent(http.StatusInternalServerError)

--- a/extra/jiaapi-mock/go.mod
+++ b/extra/jiaapi-mock/go.mod
@@ -3,7 +3,7 @@ module github.com/isucon/isucon11-qualify/jiaapi-mock
 go 1.16
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/labstack/echo/v4 v4.3.0
 	github.com/labstack/gommon v0.3.0
 )

--- a/extra/jiaapi-mock/model/isu_poster_manager.go
+++ b/extra/jiaapi-mock/model/isu_poster_manager.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"net/url"
 	"sync"
 )
 
@@ -14,8 +15,8 @@ func NewIsuConditionPosterManager() *IsuConditionPosterManager {
 	return &IsuConditionPosterManager{activatedIsu, sync.Mutex{}}
 }
 
-func (m *IsuConditionPosterManager) StartPosting(targetURL string, isuUUID string) error {
-	key := getKey(targetURL, isuUUID)
+func (m *IsuConditionPosterManager) StartPosting(targetURL *url.URL, isuUUID string) error {
+	key := getKey(targetURL.String(), isuUUID)
 
 	conflict := func() bool {
 		m.activatedIsuMtx.Lock()


### PR DESCRIPTION
## やったこと

## 対応issue

- resolved #969

## セルフチェック

- [ ] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
