### PR TITLE
fix(backend): Return 500 when the last condition contains unexpected warn count

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -489,6 +489,7 @@ func getIsuList(c echo.Context) error {
 			conditionLevel, err := calculateConditionLevel(lastCondition.Condition)
 			if err != nil {
 				c.Logger().Error(err)
+				return c.NoContent(http.StatusInternalServerError)
 			}
 
 			formattedCondition = &GetIsuConditionResponse{


### PR DESCRIPTION
## やったこと
#906 で `return c.NoContent(http.StatusInternalServerError)` が消えてるのはミスだと思ったんですがどうでしょうか。
https://github.com/isucon/isucon11-qualify/pull/906/files#diff-871eb89e86e63e7eca84f0075cba1a75574a11341cd89d39c7891864d2b085b9L498

## 対応issue

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
