### PR TITLE
fix(bench): do not use default.jpg

### DIFF
--- a/bench/random/image.go
+++ b/bench/random/image.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math/rand"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 
 	"github.com/anthonynsimon/bild/adjust"
@@ -31,6 +32,10 @@ func init() {
 
 	for i := 0; i < imageNum; i++ {
 		fileInfo := files[rand.Intn(len(files))]
+		//default.jpg以外の、.jpgで終わるファイルに限定する
+		for fileInfo.Name() == "default.jpg" || !strings.HasSuffix(fileInfo.Name(), ".jpg") {
+			fileInfo = files[rand.Intn(len(files))]
+		}
 		img, err := imgio.Open(filepath.Join(imageFolderPath, fileInfo.Name()))
 		if err != nil {
 			log.Fatalf("%+v", err)


### PR DESCRIPTION
## やったこと
default.jpgをpostしないように
## 対応issue
close #1021
## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
流石にDBの中までは見に行っていないが、default.jpgを引いたときに再取得が走るのは確認した