### PR TITLE
fix(backend) routeを明示的に指定

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -232,6 +232,8 @@ func main() {
 	e.GET("/", getIndex)
 	e.GET("/condition", getIndex)
 	e.GET("/isu/:jia_isu_uuid", getIndex)
+	e.GET("/isu/:jia_isu_uuid/condition", getIndex)
+	e.GET("/isu/:jia_isu_uuid/graph", getIndex)
 	e.GET("/register", getIndex)
 	e.GET("/login", getIndex)
 	e.Static("/assets", frontendContentsPath+"/assets")


### PR DESCRIPTION
## やったこと

- `/isu/:jia_isu_uuid/condition` と `/isu/:jia_isu_uuid/graph` を明示的に getIndex にルーティングするようにした
  - echo ではこれがなくても `/isu/:jia_isu_uuid` のルーティングに引っかがって問題なかったが、読む人からわかりにくい & 多言語移植時に困ったので

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
