### PR TITLE
feat(bench) OpenMetricsフォーマットでベンチ実行結果を吐くようにした

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -148,6 +148,10 @@ func (p PromTags) writePromFile() {
 }
 
 func (p PromTags) commit() {
+	if len(promOut) == 0 {
+		return
+	}
+
 	promOutNew := fmt.Sprintf("%s.new", promOut)
 	err := os.Rename(promOutNew, promOut)
 	if err != nil {


### PR DESCRIPTION
## やったこと

- ベンチ実行時に `-prom-out $FILEPATH` オプションを与えると $FILEPATH に OpenMetrics フォーマットのメトリクスを吐くようにした
    - このファイルを Prometheus が読めるように node-exporter で監視するのは別 PR で実施

## 対応issue

- #1066

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
