### PR TITLE
[bench]: 詳細のタグはコンテスタントには見せない

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -200,11 +200,13 @@ func sendResult(s *scenario.Scenario, result *isucandar.BenchmarkResult, finish 
 		logger.AdminLogger.Printf("SCORE: %s: %d", p.Tag, p.Count)
 		promTags = append(promTags, fmt.Sprintf("xsuconbench_score_breakdown{name=\"%s\"} %d\n", strings.TrimRight(string(p.Tag), " "), p.Count))
 	}
-	for _, p := range tagCountPair {
-		if p.Tag[0] == '_' {
-			break //詳細のタグはコンテスタントには見せない
+	if finish {
+		for _, p := range tagCountPair {
+			if p.Tag[0] == '_' {
+				break //詳細のタグはコンテスタントには見せない
+			}
+			logger.ContestantLogger.Printf("SCORE: %s: %d", p.Tag, p.Count)
 		}
-		logger.ContestantLogger.Printf("SCORE: %s: %d", p.Tag, p.Count)
 	}
 
 	for _, err := range errors {


### PR DESCRIPTION
## やったこと

詳細のタグはコンテスタントには見せない
必要かどうか分からないけど、必要になったときにワンクリックで入れられるようにPRだけは立てておきます

## 対応issue
close #1144
## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
