### PR TITLE
timeout1秒でもサーバ上で初期実装が動くので1sに変更

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -103,7 +103,7 @@ func init() {
 
 	var jiaServiceURLStr, timeoutDuration, initializeTimeoutDuration string
 	flag.StringVar(&jiaServiceURLStr, "jia-service-url", getEnv("JIA_SERVICE_URL", "http://apitest:5000"), "jia service url")
-	flag.StringVar(&timeoutDuration, "timeout", "5s", "request timeout duration")
+	flag.StringVar(&timeoutDuration, "timeout", "1s", "request timeout duration")
 	flag.StringVar(&initializeTimeoutDuration, "initialize-timeout", "20s", "request timeout duration of POST /initialize")
 
 	flag.Parse()


### PR DESCRIPTION
## やったこと
benchmarkerのloadのrequest timeoutを1sにしても問題なさそうだったので戻しました。

## 対応issue
* https://github.com/isucon/isucon11-qualify/issues/1026

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
実際にサーバ上でgoの初期実装に対してtimeoutを1sで実行した結果
```
19:08:24.565456 <=== LOAD END
19:08:24.565528 SCORE: 00.StartBenchmark       : 1
19:08:24.565566 SCORE: 05.GraphWorst           : 7
19:08:24.565583 SCORE: 10.TodayGraphWorst      : 3
19:08:24.565630 SCORE: 11.ReadInfoCondition    : 6
19:08:24.565642 SCORE: 12.ReadWarningCondition : 4
19:08:24.565648 SCORE: _1.IsuInitialize        : 6
19:08:24.565654 SCORE: _2.NormalUserInitialize : 2
19:08:24.565660 SCORE: _3.ViewerInitialize     : 3
19:08:24.565666 SCORE: _4.ViewerDropout        : 3
19:08:24.565673 SCORE: _5.RepairIsu            : 2
19:08:24.565679 SCORE: _6.PostInfoCondition    : 176
19:08:24.565686 SCORE: _7.PostWarningCondition : 743
19:08:24.565697 SCORE: _8.PostCriticalCondition: 1757
19:08:24.567042 score: 1392(1402 - 10) : pass
19:08:24.567049 deduction: 0 / timeout: 100
19:08:24.567059 <=== sendResult finish
```