### PR TITLE
fix(doc) 当日マニュアルの”作業手順”の節を読みやすくなるよう修正

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -116,6 +116,12 @@ Host isucon-server3
   - 競技終了後の作業は禁止行為にあたり失格となります。
 - **サーバー上の `isucon` 以外のユーザに関して、ユーザ削除や既存の公開鍵の削除、その他 sshd の設定変更等を行ったことにより、主催者による追試をおこなうことができない場合は、失格とします。**
 
+#### 競技環境の再構築方法
+
+選手自らが設定変更等により競技環境を破壊し復旧できなくなった際は、上記「テンプレートでのスタックの作成」を参考に選手自らが AWS CloudFormation で新たに競技環境の構築を行うことになります。再構築の際は、 AWS CloudFormation で既存のスタックとは異なる名前で新しいスタックを作成します。古い競技環境は競技リソースとして利用することができないため、古い競技環境のスタックは削除が必要となります。
+新規競技環境は競技開始時点の初期状態となります。古い競技環境上で変更を加えたソースコードや設定ファイル等の移行が必要な場合は、各チームの責任で行ってください。
+
+TODO: 再構築手順を実際に確認（スタック名の変更は必要か、ポータル側が上書きされているか、古い競技環境を消さないとチェックスクリプトがどうなるか、etc...）
 
 ## 作業手順
 
@@ -123,31 +129,48 @@ Host isucon-server3
 
 ### 1. サーバーへのログイン
 
-上記に記載したサーバーに対して SSH 接続してください。
+`3. インスタンスへの SSH` 節に示した三台のサーバーのいずれかに対して SSH 接続してください。
 ログインには参加登録に利用した ( = ポータルのログインに利用している) GitHub アカウントに登録されている SSH 鍵を利用します。
 
 SSH ログインのユーザ名は `isucon` です。
 
 ### 2. アプリケーションの動作確認
 
-アプリケーションは Web ブラウザから動作確認をすることができます。
+Web ブラウザで以下の URL にアクセスすることで， ISUCONDITION のトップページを閲覧できます。
 
-#### アプリケーションへのログイン方法
+- `https://<Elastic IP アドレス 1,2,3>:5000/`
 
-アプリケーションは所定の手順で起動された EC2 インスタンス上で起動した状態となっています。
-以下は `https://<Elastic IP アドレス 1>` でアプリケーションへ、`https://<Elastic IP アドレス 1>:5000` で JIA へアクセスする場合の例です。
+なお、ブラウザから ISUCONDITION のすべての機能の動作確認をするには、ブラウザからサーバー内部のJIA API Mockへアクセスできるようにするため、ポートフォワーディングの設定が必要です．
+詳細は `ブラウザからの ISUCONDITION の動作確認` の節を確認してください．
 
-- ISUCONDITION トップページ
-  - `https://<Elastic IP アドレス 1>/`
+### 3. 負荷走行 (ベンチマーク)
 
+** ToDo **
+- ポータルサイトのページ名を確認し修正
+- 可能であれば参加者を「選手」もしくは「予選参加者」に修正
 
-- JIA のログインページ
-  - `https://<Elastic IP アドレス 1>:5000/`
+負荷走行はポータルサイト上からリクエストします。
+ポータルサイトの [競技参加者向けページ](https://portal.isucon.net/contestant) にアクセスし、 "Job Enqueue Form" から負荷走行対象のサーバーを選択、"Enqueue" をクリックすることで負荷走行のリクエストが行われ、順次開始されます。
 
-MEMO: 本番ではHTTPSで接続できるようにするので `/etc/hosts` 周りの話を追記する
+なお、負荷走行が待機中 (PENDING) もしくは実行中 (RUNNING) の間は追加の Enqueue を行うことはできません。
+
+## ブラウザからの ISUCONDITION の動作確認
+
+### 2.1 ポートフォワーディング
+
+ブラウザから ISUCONDITION の動作確認をするには、ブラウザからサーバー上の 5000番ポートで待ち受けている JIA API Mock へアクセスできるようにするため、ポートフォワーディングが必要です。
+
+以下に[SSH におけるローカルポートフォワーディング](https://help.ubuntu.com/community/SSH/OpenSSH/PortForwarding#Local_Port_Forwarding) を実行するコマンドを例示します。
+これは「リモートホスト `isucon-server1` に SSH 接続をした上で」「ローカルの `localhost:5000` への TCP 接続を」「リモートホストを通して `isucondition-1.t.isucon.dev` へ転送する」というコマンドです。
+
+```shell
+$ ssh -L localhost:5000:isucondition-1.t.isucon.dev:5000 isucon-server1
+```
+
+### 2.2 ISUCONDITION へのログイン
 
 ログインには Japan ISU Association（以下 JIA）のアカウントが必要です。
-下記の 4 ユーザが登録されているので、動作確認にご利用ください。ログインはトップページから行うことができます。
+下記の 4 ユーザが登録されているので、動作確認にご利用ください。
 
 | ログイン ID (contestant_id) | パスワード | 備考       |
 |-----------------------------|------------|------------|
@@ -156,7 +179,14 @@ MEMO: 本番ではHTTPSで接続できるようにするので `/etc/hosts` 周�
 | isucon2                     | isucon2    | 初期ユーザ |
 | isucon3                     | isucon3    | 初期ユーザ |
 
-#### ISU の登録に使える JIA ISU IDについて
+MEMO: 本番ではHTTPSで接続できるようにするので `/etc/hosts` 周りの話を追記する
+
+### 2.3 ISU の登録
+
+ISU の登録はログイン後に以下のURLで行うことができます。
+以下のURLには ISUCONDITION の「ISUの登録」ボタンからも遷移できます
+
+- `https://<Elastic IP アドレス 1,2,3>/register`
 
 アプリケーションの動作確認用に以下の JIA ISU ID が登録に使うことができます。
 
@@ -173,93 +203,39 @@ MEMO: 本番ではHTTPSで接続できるようにするので `/etc/hosts` 周�
 | 57d600ef-15b4-43bc-ab79-6399fab5c497 |
 | aa0844e6-812d-41d2-908a-eeb82a50b627 |
 
-ISU の登録はログイン後に以下のURLで行うことができます。
+ISU を登録すると、 JIA API Mockから指定された URL へのコンディションの送信が開始されます。
 
-- `https://<Elastic IP アドレス 1>/register`
+### JIA API Mock
 
-#### データベースの初期化方法
+JIA API Mock は、開発用に用いられる JIA API のモックです。
+JIA API Mock は、サーバーの5000番で待ち受けています。
+
+JIA API Mock は以下のエンドポイントと、 ISU からのコンディション送信を模擬したリクエストを送る機能を持っています。
+
+- `POST /api/auth` - ISUCONDITION へログインするためのトークンの発行
+- `POST /api/activate` - ISU の登録（アクティベート）
+- 登録した仮想 ISU から ISUCONDITION へ向けたコンディションの送信
+
+- JIA のログインページ
+  - `https://<Elastic IP アドレス 1>:5000/`
+
+JIA API のエンドポイントの仕様は [ISUCONDITION アプリケーションマニュアル](./isucondition.md)を参照してください。
+
+JIA API Mock は ISU を登録（アクティベート）すると、指定されたURLへのコンディションの送信を開始します。
+登録したISUからのコンディション送信を止める場合は、 JIA API Mock のサービスを以下のように再起動して下さい。
+
+```shell
+$ sudo systemctl restart jiaapi-mock.service
+```
+
+### データベースの初期化方法
 
 初期状態のアプリケーションでは、初期化処理（`POST /initialize`）においてデータベースを初期状態に戻します。
 次のコマンドを実行してもデータベースを初期状態に戻すことができます。
 
 ```
-~isucon/webapp/sql/init.sh
+$ ~isucon/webapp/sql/init.sh
 ```
-
-#### 競技環境の再構築方法
-
-選手自らが設定変更等により競技環境を破壊し復旧できなくなった際は、上記「テンプレートでのスタックの作成」を参考に選手自らが AWS CloudFormation で新たに競技環境の構築を行うことになります。再構築の際は、 AWS CloudFormation で既存のスタックとは異なる名前で新しいスタックを作成します。古い競技環境は競技リソースとして利用することができないため、古い競技環境のスタックは削除が必要となります。
-新規競技環境は競技開始時点の初期状態となります。古い競技環境上で変更を加えたソースコードや設定ファイル等の移行が必要な場合は、各チームの責任で行ってください。
-
-TODO: 再構築手順を実際に確認（スタック名の変更は必要か、ポータル側が上書きされているか、古い競技環境を消さないとチェックスクリプトがどうなるか、etc...）
-
-#### 動作確認に必要なアプリケーション
-
-JIA API Mock は JIA のページを模したアプリケーションであり、ローカルでの開発/動作検証に利用することができます。
-
-JIA API Mockは以下の2つのエンドポイントと ISU からのコンディション送信を模擬したリクエストを送る機能を持っています。
-
-- `POST /api/auth` - ISUCONDITION へログインするためのトークンの発行
-- `POST /api/activate` - 仮想 ISU の登録（アクティベート）
-- 登録した仮想 ISU から ISUCONDITION へ向けたコンディションの送信
-
-JIA APIについての詳細は [ISUCONDITION アプリケーションマニュアル](./isucondition.md)を参照してください。
-
-登録した仮想 ISU からのコンディション送信を止める場合は JIA API Mock のサービスを以下のように再起動して下さい。
-
-```shell
-sudo systemctl restart jiaapi-mock.service
-```
-
-#### ローカルでの開発方法
-
-ローカルでの動作検証にはサーバー上の JIA API Mock への [SSH におけるローカルポートフォワーディング](https://help.ubuntu.com/community/SSH/OpenSSH/PortForwarding#Local_Port_Forwarding) が必要ですが、これ以外の方法で開発をしてもかまいません。
-
-以下にローカルポートフォワーディングを実行するコマンドを例示します。
-これは「リモートホスト `isucon-server1` に SSH 接続をした上で」「ローカルの `localhost:5000` への TCP 接続を」「リモートホストを通して `isucondition-1.t.isucon.dev` へ転送する」というコマンドです。
-
-```shell
-$ ssh -L localhost:5000:isucondition-1.t.isucon.dev:5000 isucon-server1
-```
-
-以上を踏まえると、上記のコマンド例を実行している場合、 `http://localhost:5000` で JIA API Mock へアクセスすることができます。
-
-アプリケーションに JIA の URL を指定する場合は `POST /initialize` の際に以下のように指定をします。
-
-```
-curl -sf -H 'content-type: application/json' http://localhost:3000/initialize -d '{"jia_service_url": "http://localhost:5000"}'
-```
-
-アプリケーションの動作確認はWebブラウザから行うことができますが、下記のようにトークンの取得と cookie の設定を行うことでコンソールからも API へのアクセスが可能です。
-
-```
-TOKEN=`curl -sf -H 'content-type: application/json' http://localhost:5000/api/auth -d '{"user": "isucon", "password": "isucon"}'`
-curl -c cookie.txt -vf -XPOST -H "authorization: Bearer ${TOKEN}" http://localhost:3000/api/auth
-curl -b cookie.txt http://localhost:3000/api/isu
-```
-
-`POST /api/condition/:jia_isu_uuid` の検証を行うには、"ISU の登録に使える JIA ISU ID について" に記載されている JIA ISU ID を用います。
-アクティベートを行った ISU から送信されるコンディションは下記の様にデータを送信することが可能です。
-
-```
-export JIA_ISU_UUID=0694e4d7-dfce-4aec-b7ca-887ac42cfb8f
-curl -XPOST -H 'content-type: application/json' http://localhost:3000/api/condition/${JIA_ISU_UUID} \
--d '[{"is_sitting": true, "condition": "is_dirty=true,is_overweight=true,is_broken=true","message":"test","timestamp": 1628492991}]'
-```
-
-この他にも [SSH Remote Port Forwarding](https://help.ubuntu.com/community/SSH/OpenSSH/PortForwarding#Remote_Port_Forwarding) を利用してサーバ上からローカルに ISU から送信されるコンディションを送る方法がありますが、詳細は省略します。
-
-### 3. 負荷走行 (ベンチマーク)
-
-** ToDo **
-- ポータルサイトのページ名を確認し修正
-- 可能であれば参加者を「選手」もしくは「予選参加者」に修正
-
-負荷走行はポータルサイト上からリクエストします。
-ポータルサイトの [競技参加者向けページ](https://portal.isucon.net/contestant) にアクセスし、 "Job Enqueue Form" から負荷走行対象のサーバーを選択、"Enqueue" をクリックすることで負荷走行のリクエストが行われ、順次開始されます。
-
-なお、負荷走行が待機中 (PENDING) もしくは実行中 (RUNNING) の間は追加の Enqueue を行うことはできません。
-
 
 ### 参考実装
 


### PR DESCRIPTION
## やったこと
* 作業手順の ”2 アプリケーションの動作確認” の中にあった"ブラウザで動作確認するための設定"の説明を後ろへ持っていった
  - 動作確認はとりあえずトップページだけ見られればいいという想定。初めから情報量が多すぎると混乱する気がするので
* 「競技環境の再構築方法」を前に持っていった
* "ローカルでの開発方法"にあったcurlを使ったコマンド例を消した
  - やり方の例を示すよりも、 JIA APImockのAPIドキュメントとして示すべきだと思う
  - あと、色々細かく書いてしまうと、それはそれで競技者を混乱させてしまうはず
* 表現の修正や、「詳しくはここを見てください」などの文言の追加  

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
一つの提案なので、問題なかったらとりあえずマージしてもらって、そこからさらにいじってもらって大丈夫です