### PR TITLE
[backend]: graphのfilter処理が間違っていた

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -830,10 +830,10 @@ func generateIsuGraphResponse(tx *sqlx.Tx, jiaIsuUUID string, graphDate time.Tim
 	}
 
 	endTime := graphDate.Add(time.Hour * 24)
-	startIndex := 0
+	startIndex := len(dataPoints)
 	endNextIndex := len(dataPoints)
 	for i, graph := range dataPoints {
-		if startIndex == 0 && !graph.StartAt.Before(graphDate) {
+		if startIndex == len(dataPoints) && !graph.StartAt.Before(graphDate) {
 			startIndex = i
 		}
 		if endNextIndex == len(dataPoints) && graph.StartAt.After(endTime) {


### PR DESCRIPTION
## やったこと

graphのfilter処理が間違っていた
先頭一時間分が欠損する可能性があった

## 対応issue
#1146

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
