### PR TITLE
[bench] TrendIgnoreのapiアクセスに対するエラーを無視するように変更

### DIFF
--- a/bench/scenario/action.go
+++ b/bench/scenario/action.go
@@ -578,18 +578,19 @@ func browserGetLandingPageAction(ctx context.Context, a *agent.Agent) (service.G
 	return trend, res, nil
 }
 
-func browserGetLandingPageIgnoreAction(ctx context.Context, a *agent.Agent) (*http.Response, error) {
+func browserGetLandingPageIgnoreAction(ctx context.Context, a *agent.Agent) error {
 	// 静的ファイルのGET
 	if err := BrowserAccess(ctx, a, "/", TrendPage); err != nil {
-		return nil, err
+		return err
 	}
 
-	res, err := getTrendIgnoreAction(ctx, a)
+	_, err := getTrendIgnoreAction(ctx, a)
 	if err != nil {
-		return nil, err
+		// ここのエラーは気にしないので握りつぶす
+		return nil
 	}
 
-	return res, nil
+	return nil
 }
 
 func getTrendIgnoreAction(ctx context.Context, a *agent.Agent) (*http.Response, error) {

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -875,8 +875,7 @@ func signoutScenario(ctx context.Context, step *isucandar.BenchmarkStep, user *m
 	// signout したらトップページに飛ぶ(MEMO: 初期状態だと trend おもすぎて backend をころしてしまうかも)
 	go func() {
 		// 登録済みユーザーは trend に興味はないので verify はせず投げっぱなし
-		_, err = browserGetLandingPageIgnoreAction(ctx, user.Agent)
-		if err != nil {
+		if err := browserGetLandingPageIgnoreAction(ctx, user.Agent); err != nil {
 			addErrorWithContext(ctx, step, err)
 			// return するとこのあとのログイン必須なシナリオが回らないから return はしない
 		}

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -149,7 +149,7 @@ func (s *Scenario) NewUser(ctx context.Context, step *isucandar.BenchmarkStep, a
 	//backendにpostする
 	go func() {
 		// 登録済みユーザーは trend に興味がないからリクエストを待たない
-		if _, err := browserGetLandingPageIgnoreAction(ctx, a); err != nil {
+		if err := browserGetLandingPageIgnoreAction(ctx, a); err != nil {
 			addErrorWithContext(ctx, step, err)
 		}
 	}()


### PR DESCRIPTION
## やったこと
* PrepareでTrendのapiエラーを拾ってしまっていたので対応
  * getTrendIgnoreAction自体のエラーは無視して良さそうだったので無視
  * 握りつぶしたときにresponse内容が正常でないのと、そもそもresponse内容を利用してなかったのでbrowserGetLandingPageIgnoreActionはerrorのみ返すように変更

## 対応issue
* https://github.com/isucon/isucon11-qualify/issues/1169

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
