### PR TITLE
[initial-data] 初期データを減らした

### DIFF
--- a/extra/initial-data/models/isu.go
+++ b/extra/initial-data/models/isu.go
@@ -58,6 +58,24 @@ func NewIsuWithCreatedAt(user User, createdAt time.Time) Isu {
 	}
 }
 
+func NewIsuWithCharacterId(user User, characterID int) Isu {
+	u, _ := uuid.NewRandom()
+	createdAt := random.TimeAfterArg(user.CreatedAt)
+
+	image := defaultImage()
+	character := random.CharacterData[characterID%len(random.CharacterData)]
+
+	return Isu{
+		user,
+		u.String(),
+		random.IsuName(),
+		image,
+		character,
+		characterID,
+		createdAt,
+		createdAt,
+	}
+}
 func defaultImage() []byte {
 	bytes, err := ioutil.ReadFile(defaultImagePath)
 	if err != nil {


### PR DESCRIPTION
## やったこと
* 初期データを減らしても問題無いようなので、データ量を減少させました
  * isucon以外のランダムユーザを生成しないようにした
  * isuconユーザのconditionを雑に減らした
  * isuに関しては全性格無いとtrendのverifyで落ちるので全性格1台ずつ用意出来るようにuser1人あたりのisuの数増やして、characterID指定して生成するようにした

## 対応issue
 * https://github.com/isucon/isucon11-qualify/issues/1069

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
