### PR TITLE
fix(jiaapi-mock) conditionをpostしたときのステータスコードが202のとき、JIA API Mockでエラーログを出さないようにした

### DIFF
--- a/extra/jiaapi-mock/model/isu_poster.go
+++ b/extra/jiaapi-mock/model/isu_poster.go
@@ -87,8 +87,8 @@ func (m *IsuConditionPoster) KeepPosting() {
 			}
 			defer resp.Body.Close()
 
-			if resp.StatusCode != 201 && resp.StatusCode != 202 {
-				log.Errorf("failed to `POST %s` with status=`%s`", targetURL, resp.Status)
+			if resp.StatusCode != 202 {
+				log.Errorf("`POST %s` returned unexpected status code `%s`", targetURL.String(), resp.Status)
 				return // goto next loop
 			}
 		}()


### PR DESCRIPTION
## やったこと
* conditionをpostしたときのステータスコードが202のとき、JIA API Mockでエラーログを出さないようにしました
  - 競技者がJIAAPI Mockのログを見た時、混乱させないようにするため

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
