### PR TITLE
feat(nodejs): Throw custom Error in getUserIdFromSession

### DIFF
--- a/webapp/nodejs/src/app.ts
+++ b/webapp/nodejs/src/app.ts
@@ -156,6 +156,7 @@ class ErrorWithStatus extends Error {
   public status: number;
   constructor(status: number, message: string) {
     super(message);
+    this.name = new.target.name;
     this.status = status;
   }
 }


### PR DESCRIPTION
## やったこと

`getUserIdFromSession` で status code と message を返すのではなく Error としてthrowする形に変えてみた

## 対応issue

https://github.com/isucon/isucon11-qualify/pull/452#discussion_r688974642

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
