### PR TITLE
fix(sql) スキーマ定義に残っていたTODOコメントを削除

### DIFF
--- a/webapp/sql/0_Schema.sql
+++ b/webapp/sql/0_Schema.sql
@@ -1,5 +1,3 @@
--- TODO: 各カラムの varchar の大きさを調整する (#51)
-
 DROP TABLE IF EXISTS `isu_association_config`;
 DROP TABLE IF EXISTS `isu_condition`;
 DROP TABLE IF EXISTS `isu`;


### PR DESCRIPTION
## やったこと
* スキーマ定義のファイルに、「varcharの長さを変える」というTODOコメントが残っていたので消しました

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
