### PR TITLE
[bench] isu.Icon が nil のときはエラーを出さないようにした

### DIFF
--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -260,9 +260,12 @@ func (s *Scenario) loadNormalUser(ctx context.Context, step *isucandar.Benchmark
 			if err != nil {
 				errs = append(errs, err)
 			}
-			err = verifyIsuIcon(targetIsu, isu.Icon, isu.IconStatusCode)
-			if err != nil {
-				errs = append(errs, err)
+			// isu.Icon が nil じゃないときはすでにエラーを追加している
+			if isu.Icon != nil {
+				err = verifyIsuIcon(targetIsu, isu.Icon, isu.IconStatusCode)
+				if err != nil {
+					errs = append(errs, err)
+				}
 			}
 			return errs
 		})


### PR DESCRIPTION
## やったこと

## 対応issue
Close #1281 

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
