### PR TITLE
fix(ruby): Fix /api/trend API

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -599,9 +599,9 @@ module Isucondition
           end
         end
 
-        character_info_isu_conditions.sort! { |a,b| a.fetch(:timestamp) <=> b.fetch(:timestamp) }
-        character_warning_isu_conditions.sort! { |a,b| a.fetch(:timestamp) <=> b.fetch(:timestamp) }
-        character_critical_isu_conditions.sort! { |a,b| a.fetch(:timestamp) <=> b.fetch(:timestamp) }
+        character_info_isu_conditions.sort! { |a,b| b.fetch(:timestamp) <=> a.fetch(:timestamp) }
+        character_warning_isu_conditions.sort! { |a,b| b.fetch(:timestamp) <=> a.fetch(:timestamp) }
+        character_critical_isu_conditions.sort! { |a,b| b.fetch(:timestamp) <=> a.fetch(:timestamp) }
 
         {
           character: character.fetch(:character),


### PR DESCRIPTION
## やったこと
prepare では検出できていない /api/trend のバグを直します。

- to_json 漏れ
- TrendCondition のフィールド名は `id` ではなく `isu_id` https://github.com/isucon/isucon11-qualify/blob/08.17.2/webapp/go/main.go#L157
- TrendCondition のソート順は降順 https://github.com/isucon/isucon11-qualify/blob/08.17.2/webapp/go/main.go#L1137-L1145

## 対応issue

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考

cc @sorah 