### PR TITLE
envchecker: Retry request on some operations

### DIFF
--- a/extra/envchecker/isucon-env-checker/backoff.go
+++ b/extra/envchecker/isucon-env-checker/backoff.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+func newBackoff() backoff.BackOff {
+	b := &backoff.ExponentialBackOff{
+		InitialInterval:     1 * time.Second,
+		RandomizationFactor: 0.25,
+		Multiplier:          2,
+		MaxInterval:         10 * time.Second,
+		MaxElapsedTime:      30 * time.Second,
+		Stop:                backoff.Stop,
+		Clock:               backoff.SystemClock,
+	}
+	b.Reset()
+	return b
+}

--- a/extra/envchecker/isucon-env-checker/go.mod
+++ b/extra/envchecker/isucon-env-checker/go.mod
@@ -2,4 +2,7 @@ module github.com/isucon/isucon11-qualify/envchecker/isucon-env-checker
 
 go 1.16
 
-require github.com/aws/aws-sdk-go v1.40.7
+require (
+	github.com/aws/aws-sdk-go v1.40.7
+	github.com/cenkalti/backoff/v4 v4.1.1
+)

--- a/extra/envchecker/isucon-env-checker/go.sum
+++ b/extra/envchecker/isucon-env-checker/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go v1.40.7 h1:dD5+UZxedqHeE4WakJHEhTsEARYlq8kHkYEf89R1tEo=
 github.com/aws/aws-sdk-go v1.40.7/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=


### PR DESCRIPTION
## やったこと

環境チェッカーで Public IP の取得またはポータルとの通信でエラーが発生した場合にはリトライが行われるようにしました。
`run-isucon-env-checker.sh` によるチェッカー単位でのリトライもありますが、起きやすそうな部分ではそこだけ個別にリトライすることで早く完了できるようになるのを期待しています。

Public IP の取得はチェッカーが AWS に送る一番最初のリクエストで、エラー発生確率が高いことがわかっています。
ポータルについては、負荷等で重たくてエラーになる場合などが想定できたので仕込みました。

## 対応issue

https://github.com/isucon/isucon11-portal/issues/180

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
