### PR TITLE
fix(jiaapi-mock) targetURLのみが異なっていてISU IDが重複する場合の登録も認めないようにした

### DIFF
--- a/extra/jiaapi-mock/model/isu_poster_manager.go
+++ b/extra/jiaapi-mock/model/isu_poster_manager.go
@@ -16,19 +16,17 @@ func NewIsuConditionPosterManager() *IsuConditionPosterManager {
 }
 
 func (m *IsuConditionPosterManager) StartPosting(targetURL *url.URL, isuUUID string) error {
-	key := getKey(targetURL.String(), isuUUID)
-
 	conflict := func() bool {
 		m.activatedIsuMtx.Lock()
 		defer m.activatedIsuMtx.Unlock()
-		if _, ok := m.activatedIsu[key]; ok {
+		if _, ok := m.activatedIsu[isuUUID]; ok {
 			return true
 		}
-		m.activatedIsu[key] = NewIsuConditionPoster(targetURL, isuUUID)
+		m.activatedIsu[isuUUID] = NewIsuConditionPoster(targetURL, isuUUID)
 		return false
 	}()
 	if !conflict {
-		isu := m.activatedIsu[key]
+		isu := m.activatedIsu[isuUUID]
 		go isu.KeepPosting()
 	}
 	return nil

--- a/extra/jiaapi-mock/model/utils.go
+++ b/extra/jiaapi-mock/model/utils.go
@@ -1,5 +1,0 @@
-package model
-
-func getKey(targetURL string, isuUUID string) string {
-	return isuUUID + targetURL
-}


### PR DESCRIPTION
## やったこと

## 対応issue
resolved #1332 

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
* #1321 を修正して新たに立てました