### PR TITLE
fix(bench): Include query string when reporting error

### DIFF
--- a/bench/scenario/error.go
+++ b/bench/scenario/error.go
@@ -131,7 +131,7 @@ func errorBadResponse(res *http.Response, message string, args ...interface{}) e
 }
 
 func errorFormatWithResponse(res *http.Response, message string, args ...interface{}) error {
-	return errorFormatWithURI(res.StatusCode, res.Request.Method, res.Request.URL.Path, message, args...)
+	return errorFormatWithURI(res.StatusCode, res.Request.Method, res.Request.URL.RequestURI(), message, args...)
 }
 func errorFormatWithURI(statusCode int, method string, urlPath string, message string, args ...interface{}) error {
 	args = append(args, statusCode, method, urlPath)


### PR DESCRIPTION
## やったこと
`GET /api/isu/:jia_isu_uuid/graph` や `GET /api/condition/:jia_isu_uuid` のようにクエリ文字列を受け取るようなエンドポイントのレスポンスが verify 対象になっていて、パスだけでなくクエリ文字列もベンチマーカからのエラーログに含めたほうが選手にとってはデバッグしやすそうです。
直前の変更となってしまうのでマージするかどうかは writer 陣におまかせします。

## 対応issue

## セルフチェック
- [ ] 静的解析
- [x] ビルドが通る
- [ ] 動作確認

## 備考
