### PR TITLE
fix(python) trendのtimestamp並び順を修正

### DIFF
--- a/webapp/python/main.py
+++ b/webapp/python/main.py
@@ -710,9 +710,9 @@ def get_trend():
                 elif condition_level == "critical":
                     character_critical_isu_conditions.append(trend_condition)
 
-        character_info_isu_conditions.sort(key=lambda c: c.timestamp)
-        character_warning_isu_conditions.sort(key=lambda c: c.timestamp)
-        character_critical_isu_conditions.sort(key=lambda c: c.timestamp)
+        character_info_isu_conditions.sort(key=lambda c: c.timestamp, reverse=True)
+        character_warning_isu_conditions.sort(key=lambda c: c.timestamp, reverse=True)
+        character_critical_isu_conditions.sort(key=lambda c: c.timestamp, reverse=True)
 
         res.append(
             TrendResponse(


### PR DESCRIPTION
## やったこと
trendの並び順が降順でなく昇順になっていそうなため修正
https://isucon.slack.com/archives/C027M58K4E4/p1629251433456900


## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
