### PR TITLE
[bench] authリダイレクト時にクエリパラメータにjwt付与

### DIFF
--- a/bench/scenario/action.go
+++ b/bench/scenario/action.go
@@ -71,7 +71,7 @@ func authAction(ctx context.Context, user *model.User, userID string) (*service.
 	}
 
 	// リダイレクト時のフロントアクセス
-	if errs := BrowserAccessIndexHtml(ctx, user, "/"); len(errs) != 0 {
+	if errs := BrowserAccessIndexHtml(ctx, user, "/?jwt="+jwtOK); len(errs) != 0 {
 		errors = append(errors, errs...)
 		return nil, errors
 	}


### PR DESCRIPTION
## やったこと
https://github.com/isucon/isucon11-qualify/blob/main/docs/isucondition.md#%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3
> ④ JIA 認証サイトは認証成功時にトークン（JWT: JSON Web Token）を発行し、ユーザを ISUCONDITION にリダイレクトします。リダイレクトの URL にはクエリパラメータにトークンが設定されています。

とあわせるためにクエリパラメータにjwtつけました

## 対応issue
close https://github.com/isucon/isucon11-qualify/issues/1320

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
