### PR TITLE
fix(python): Fix generate_isu_graph_response

### DIFF
--- a/webapp/python/main.py
+++ b/webapp/python/main.py
@@ -506,7 +506,7 @@ def generate_isu_graph_response(jia_isu_uuid: str, graph_date: datetime) -> list
         if start_index == len(data_points) and graph.start_at >= graph_date:
             start_index = i
         if end_next_index == len(data_points) and graph.start_at > end_time:
-            end_next_index = 1
+            end_next_index = i
 
     filtered_data_points = []
     if start_index < end_next_index:


### PR DESCRIPTION
## やったこと

```
ERR: load: mismatch: GET /api/condition/:jia_isu_uuid か GET /api/isu/:jia_isu_uuid/graph で確認された condition がありません: 200 (GET: /api/isu/fd786204-5eef-40e8-b1ea-0a1aa7b7209f/graph)
```

負荷をかけていると上記のようなエラーが出てくるのを修正(prepareでは検出されなそう)。

https://github.com/isucon/isucon11-qualify/blob/08.19.4/webapp/go/main.go#L840

手元ではこの修正によって再現しなくなることを確認しています。


## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
