### PR TITLE
fix(ruby): Fix valid_condition_format?

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -140,7 +140,7 @@ module Isucondition
 
         idx_cond_str = 0
         keys.each_with_index do |key, idx_keys|
-          return false if condition_str[idx_cond_str..-1].start_with?(key)
+          return false unless condition_str[idx_cond_str..-1].start_with?(key)
           idx_cond_str += key.size
           case
           when condition_str[idx_cond_str..-1].start_with?(value_true)


### PR DESCRIPTION
## やったこと

`valid_condition_format?` が間違っていて `POST /api/condition/:jia_isu_uuid` がすべて `400` を返していたのを修正

https://github.com/isucon/isucon11-qualify/blob/08.19.8/webapp/go/main.go#L1236

## 対応issue

## セルフチェック
- [x] 静的解析
- [x] ビルドが通る
- [x] 動作確認

## 備考
