### PR TITLE
Ruby: fix generate_isu_graph_response endtime condition

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -409,7 +409,7 @@ module Isucondition
 
       data_points.each_with_index do |graph, i|
         start_index = i if start_index == data_points.size && graph.fetch(:start_at) >= graph_date
-        end_next_index = i if end_next_index == data_points.size && graph.fetch(:start_at) >= end_time
+        end_next_index = i if end_next_index == data_points.size && graph.fetch(:start_at) > end_time
       end
 
       filtered_data_points = []


### PR DESCRIPTION
## やったこと
https://github.com/isucon/isucon11-qualify/blob/1641c3f2ec6412e23e2e0e145231d91a9b7a7263/webapp/go/main.go#L839

だったので
`graph.fetch(:start_at) >= end_time`から`graph.fetch(:start_at) > end_time`にしました

## 対応issue

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
確認は全然してないですがこうな気がしています
