### PR TITLE
fix(infra) nginx にてデフォルトで http2 を有効化

### DIFF
--- a/provisioning/ansible/roles/contestant/files/etc/nginx/sites-available/isucondition-php.conf
+++ b/provisioning/ansible/roles/contestant/files/etc/nginx/sites-available/isucondition-php.conf
@@ -1,5 +1,5 @@
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
     index index.php;
     root /home/isucon/webapp/php/public;
 

--- a/provisioning/ansible/roles/contestant/files/etc/nginx/sites-available/isucondition.conf
+++ b/provisioning/ansible/roles/contestant/files/etc/nginx/sites-available/isucondition.conf
@@ -1,5 +1,5 @@
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
 
     ssl_certificate /etc/nginx/certificates/tls-cert.pem;
     ssl_certificate_key /etc/nginx/certificates/tls-key.pem;


### PR DESCRIPTION
## やったこと

## 対応issue

* resolved #1391

## セルフチェック
- [ ] 静的解析
- [ ] ビルドが通る
- [ ] 動作確認

## 備考
