### PR TITLE
公開リポジトリになったのでgit cloneをSSHからHTTPSに変更

### DIFF
--- a/provisioning/packer/Makefile
+++ b/provisioning/packer/Makefile
@@ -19,7 +19,7 @@ files-generated/isucon11-qualify.tar: files-generated/REVISION
 files-generated/isucon11-portal.tar:
 	mkdir -p files-generated/
 	$(eval tmpdir=$(shell mktemp -d))
-	git -c core.sshCommand="ssh -i $(MAKEFILE_DIR)isucon11-portal.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -F /dev/null" clone --depth=1 git@github.com:isucon/isucon11-portal.git -b main $(tmpdir)/isucon11-portal
+	git clone --depth=1 https://github.com/isucon/isucon11-qualify.git -b main $(tmpdir)/isucon11-portal
 	cd $(tmpdir)/isucon11-portal && \
 		tar cvf $(MAKEFILE_DIR)files-generated/isucon11-portal.tar . && \
 		cd -


### PR DESCRIPTION
鍵がないと怒られちゃうのでこっちのほうが手軽かなと思い変更してみました